### PR TITLE
fix: Error with nil value on jigasi connect.

### DIFF
--- a/ansible/roles/prosody/files/mod_rate_limit.lua
+++ b/ansible/roles/prosody/files/mod_rate_limit.lua
@@ -154,7 +154,7 @@ end
 local function filter_hook(session)
     local ip = session.ip;
 	module:log("debug", "New session from %s", ip);
-    if is_whitelisted(ip) or is_whitelisted_jid(session.username..'@'..session.host) then
+    if is_whitelisted(ip) or (session.username and is_whitelisted_jid(session.username..'@'..session.host)) then
         return;
     end
 


### PR DESCRIPTION
error	Traceback[httpserver]: /usr/lib/prosody/modules/mod_rate_limit.lua:157: attempt to concatenate field 'username' (a nil value)