### PR TITLE
Adds support for public_html in nginx

### DIFF
--- a/ansible/roles/jitsi-meet/defaults/main.yml
+++ b/ansible/roles/jitsi-meet/defaults/main.yml
@@ -128,6 +128,7 @@ jitsi_meet_enable_file_recordings: false
 jitsi_meet_enable_file_recordings_service: false
 jitsi_meet_enable_file_recordings_sharing: false
 jitsi_meet_enable_forced_client_reload: false
+jitsi_meet_enable_userdirs: false
 jitsi_meet_giphy_enabled: false
 jitsi_meet_giphy_sdk_key: ''
 jitsi_meet_enable_gzip: false

--- a/ansible/roles/jitsi-meet/templates/nginx.site.j2
+++ b/ansible/roles/jitsi-meet/templates/nginx.site.j2
@@ -275,6 +275,15 @@ server {
     rewrite ^.*/static/close2.html$ {{ jitsi_meet_close_page_redirect_url }} redirect;
 {% endif %}
 
+{% if jitsi_meet_enable_userdirs %}
+    # userdirs
+    location ~ ^/~(.+?)(/.*)?$ {
+        alias /home/$1/public_html$2;
+        index  index.html index.htm;
+        autoindex on;
+    }
+{% endif %}
+
     location = /nginx_status {
       stub_status on;
       access_log   off;


### PR DESCRIPTION
This is just a small convenience feature for anyone who might want to host a quick html test file on their lonely instance. I have it configured on my lonely instance and thought to share with the team. Feel free to shoot it down 🪓 if it's not appropriate.