### PR TITLE
Make xmpp.conf and shards.conf world readable.

### DIFF
--- a/ansible/configure-jvb-local-oracle.yml
+++ b/ansible/configure-jvb-local-oracle.yml
@@ -41,13 +41,13 @@
       - name: "shards.json.template"
         dest: "/etc/jitsi/videobridge/shards.json"
         cmd: "/usr/local/bin/configure-jvb-shards.sh"
-        perms: 0640
+        perms: 0644
         backup: false
       - name: "xmpp.conf.template"
         dest: "/etc/jitsi/videobridge/xmpp.conf"
         user: "root"
         group: "jitsi"
-        perms: 0640
+        perms: 0644
         backup: false
 
   pre_tasks:


### PR DESCRIPTION
They are initially installed with 644, like the rest of the jvb config.
rtcstats-cli uses shards.json without sudo.
