### PR TITLE
add private ipv6 cidr to config to remove dupe default ipv4 routes

### DIFF
--- a/ansible/roles/firezone/defaults/main.yml
+++ b/ansible/roles/firezone/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 firezone_email: "email@example.com"
-firezone_network_ips: "10.0.0.0/8"
+firezone_network_ips: "10.0.0.0/8,fd00::/8"
 firezone_nginx_dir: "/etc/nginx"
 firezone_nginx_site_dir: "{{ firezone_nginx_dir }}/conf.d"
 firezone_nginx_ssl_dir: "{{ firezone_nginx_dir }}/ssl"


### PR DESCRIPTION
Jonathan was getting two default routes in ipv4 and the root caused seemed to be having the ipv6 address piece of this config apply to all ipv6 routes.