### PR TITLE
fix(visitors): Fixes loading some modules.

### DIFF
--- a/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
@@ -189,6 +189,9 @@ Component 'conference.v{{ item }}.meet.jitsi' 'muc'
         "rate_limit";
 {% endif %}
         'fmuc';
+        's2s_bidi';
+        's2s_whitelist';
+        's2sout_override';
 {% if prosody_visitors_muc_max_occupants %}
         'muc_max_occupants';
 {% endif %}


### PR DESCRIPTION
Loaded as global module is the same as loading it under every virtualhost (only, so not on MUCs). We need s2s_bidi and s2sout_override for the muc.