### PR TITLE
fix: Adds client-proxy to jicofo config.

### DIFF
--- a/ansible/roles/jicofo/templates/jicofo.conf.j2
+++ b/ansible/roles/jicofo/templates/jicofo.conf.j2
@@ -137,6 +137,7 @@ jicofo {
 
   xmpp {
     client {
+      client-proxy = focus.{{ prosody_domain_name }}
       domain = {{ jicofo_auth_domain }}
       username = {{ jicofo_auth_user }}
       password = {{ jicofo_auth_password }}


### PR DESCRIPTION
Fixes jibri joining a room with visitors. The conference iq from field is in correct form and we can match recorder domain to skip forwarding to visitor node.