### PR TITLE
add option to customize telegraf filter for jicofo

### DIFF
--- a/ansible/configure-core-local.yml
+++ b/ansible/configure-core-local.yml
@@ -182,7 +182,7 @@
           procstat: "{{ telegraf_inputs_procstat }}"
           prometheus:
             urls: ["http://localhost:6000/metrics", "http://localhost:8888/metrics"]
-            namepass: ["http*", "signal*", "prosody*", "jitsi_jicofo_conference_requests*"]
+            namepass: ["http*", "signal*", "prosody*", "{{ telegraf_jicofo_filter }}"]
         telegraf_tags:
           shard-role: "core"
           role: "core"

--- a/ansible/configure-standalone.yml
+++ b/ansible/configure-standalone.yml
@@ -301,7 +301,7 @@
             fieldpass: ["TcpInSegs", "TcpOutSegs", "TcpRetransSegs", "UdpInErrors", "Udp6InErrors"]
           prometheus:
             urls: ["http://localhost:6000/metrics", "http://localhost:8888/metrics"]
-            namepass: ["http*", "signal*", "jitsi_jicofo_conference_requests*"]
+            namepass: ["http*", "signal*", "{{ telegraf_jicofo_filter }}"]
         telegraf_tags:
           shard-role: "all"
           role: "all"

--- a/ansible/roles/jicofo/tasks/install.yml
+++ b/ansible/roles/jicofo/tasks/install.yml
@@ -77,6 +77,7 @@
     src: "jicofo-stats.sh.j2"
     mode: 0755
     owner: root
+  when: jicofo_enable_stats
 
 # add a stats script to upload colibri stats to DataDog
 - name: Jicofo stats python script upload
@@ -85,6 +86,7 @@
     src: "jicofo-stats.py"
     mode: 0755
     owner: root
+  when: jicofo_enable_stats
 
 - name: Jicofo health script upload
   ansible.builtin.copy:

--- a/ansible/roles/wavefront/defaults/main.yml
+++ b/ansible/roles/wavefront/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 datadog_extensions: "false"
 statsd_port: 8125
+telegraf_jicofo_filter: "jitsi_jicofo_conference_requests*"
 telegraf_additional_config_dir: "{{ telegraf_config_dir }}/telegraf.d"
 # telegraf variables
 # telegraf_config_wfcopy: "https://raw.githubusercontent.com/wavefrontHQ/integrations/master/telegraf/telegraf.conf"


### PR DESCRIPTION
- add option to customize telegraf filter for jicofo
- Only install jicofo-stats.{sh,py} when jicofo_enable_stats.
- Use telegraf_jicofo_filter for standalone, too.
