### PR TITLE
Add option to provision new accounts for jibri and jigasi.

### DIFF
--- a/ansible/jibri-auth.yml
+++ b/ansible/jibri-auth.yml
@@ -1,0 +1,14 @@
+---
+- name: Main
+  hosts: all
+  gather_facts: true
+  become: true
+  become_user: root
+  strategy: free
+  vars_files:
+    - secrets/jibri.yml
+    - config/vars.yml
+    - sites/{{ hcv_environment }}/vars.yml
+
+  roles:
+    - { role: "jibri-auth", tags: "auth" }

--- a/ansible/jigasi-auth.yml
+++ b/ansible/jigasi-auth.yml
@@ -1,0 +1,14 @@
+---
+- name: Main
+  hosts: all
+  gather_facts: true
+  become: true
+  become_user: root
+  strategy: free
+  vars_files:
+    - secrets/jigasi.yml
+    - config/vars.yml
+    - sites/{{ hcv_environment }}/vars.yml
+
+  roles:
+    - { role: "jigasi-auth", tags: "auth" }

--- a/ansible/roles/jibri-auth/defaults/main.yml
+++ b/ansible/roles/jibri-auth/defaults/main.yml
@@ -45,3 +45,10 @@ jibri_outbound_sip_path_A: "/var/lib/prosody/{{ jibri_outbound_sip_domain | rege
 jibri_outbound_sip_user_B: sipjibrioutb
 jibri_outbound_sip_path_B: "/var/lib/prosody/{{ jibri_outbound_sip_domain | regex_replace('\\.', '%2e') |
   regex_replace('-', '%2d') }}/accounts/{{ jibri_outbound_sip_user_B | regex_replace('-', '%2d') }}.dat"
+jibri_inbound_sip_domain: "auth.{{ prosody_domain_name }}"
+jibri_inbound_sip_user_A: sipjibriina
+jibri_inbound_sip_path_A: "/var/lib/prosody/{{ jibri_inbound_sip_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_inbound_sip_user_A | regex_replace('-', '%2d') }}.dat"
+jibri_inbound_sip_user_B: sipjibriinb
+jibri_inbound_sip_path_B: "/var/lib/prosody/{{ jibri_inbound_sip_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_inbound_sip_user_B | regex_replace('-', '%2d') }}.dat"

--- a/ansible/roles/jibri-auth/defaults/main.yml
+++ b/ansible/roles/jibri-auth/defaults/main.yml
@@ -22,3 +22,12 @@ outbound_sip_jibri_auth_domain_path: "/var/lib/prosody/{{ outbound_sip_jibri_aut
 outbound_sip_jibri_auth_password: "replaceme"
 outbound_sip_jibri_auth_user: "outbound-sip-jibri"
 jibri_legacy_auth: true
+# Different than the legacy username because we want to provision new accounts.
+# Note: avoid capital letters and special chars because prosody lowers/encodes them in the filename.
+jibri_brewery_domain: "auth.{{ prosody_domain_name }}"
+jibri_brewery_username_A: jibria
+jibri_brewery_path_A: "/var/lib/prosody/{{ jibri_brewery_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_brewery_username_A | regex_replace('-', '%2d') }}.dat"
+jibri_brewery_username_B: jibrib
+jibri_brewery_path_B: "/var/lib/prosody/{{ jibri_brewery_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_brewery_username_B | regex_replace('-', '%2d') }}.dat"

--- a/ansible/roles/jibri-auth/defaults/main.yml
+++ b/ansible/roles/jibri-auth/defaults/main.yml
@@ -14,10 +14,11 @@ jibri_prosody_jvb_auth_domain_name: "auth.jvb.{{ prosody_domain_name }}"
 jibri_selenium_auth_domain: "recorder.{{ prosody_domain_name }}"
 jibri_selenium_auth_domain_path: "/var/lib/prosody/{{ jibri_selenium_auth_domain | regex_replace('\\.', '%2e') |
   regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_auth_user }}.dat"
-jibri_selenium_auth_password: "jibrimeet"
+jibri_selenium_auth_password: "replaceme"
 jibri_selenium_auth_user: "recorder"
 outbound_sip_jibri_auth_domain: "auth.{{ prosody_domain_name }}"
 outbound_sip_jibri_auth_domain_path: "/var/lib/prosody/{{ outbound_sip_jibri_auth_domain | regex_replace('\\.', '%2e') |
   regex_replace('-', '%2d') }}/accounts/{{ outbound_sip_jibri_auth_user | regex_replace('-', '%2d') }}.dat"
 outbound_sip_jibri_auth_password: "replaceme"
 outbound_sip_jibri_auth_user: "outbound-sip-jibri"
+jibri_legacy_auth: true

--- a/ansible/roles/jibri-auth/defaults/main.yml
+++ b/ansible/roles/jibri-auth/defaults/main.yml
@@ -34,10 +34,10 @@ jibri_brewery_path_B: "/var/lib/prosody/{{ jibri_brewery_domain | regex_replace(
 jibri_selenium_domain: "recorder.{{ prosody_domain_name }}"
 jibri_selenium_user_A: jibria
 jibri_selenium_path_A: "/var/lib/prosody/{{ jibri_selenium_domain | regex_replace('\\.', '%2e') |
-  regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_username_A | regex_replace('-', '%2d') }}.dat"
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_user_A | regex_replace('-', '%2d') }}.dat"
 jibri_selenium_user_B: jibrib
 jibri_selenium_path_B: "/var/lib/prosody/{{ jibri_selenium_domain | regex_replace('\\.', '%2e') |
-  regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_username_B | regex_replace('-', '%2d') }}.dat"
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_user_B | regex_replace('-', '%2d') }}.dat"
 jibri_outbound_sip_domain: "auth.{{ prosody_domain_name }}"
 jibri_outbound_sip_user_A: sipjibriouta
 jibri_outbound_sip_path_A: "/var/lib/prosody/{{ jibri_outbound_sip_domain | regex_replace('\\.', '%2e') |

--- a/ansible/roles/jibri-auth/defaults/main.yml
+++ b/ansible/roles/jibri-auth/defaults/main.yml
@@ -38,3 +38,10 @@ jibri_selenium_path_A: "/var/lib/prosody/{{ jibri_selenium_domain | regex_replac
 jibri_selenium_user_B: jibrib
 jibri_selenium_path_B: "/var/lib/prosody/{{ jibri_selenium_domain | regex_replace('\\.', '%2e') |
   regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_username_B | regex_replace('-', '%2d') }}.dat"
+jibri_outbound_sip_domain: "auth.{{ prosody_domain_name }}"
+jibri_outbound_sip_user_A: sipjibriouta
+jibri_outbound_sip_path_A: "/var/lib/prosody/{{ jibri_outbound_sip_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_outbound_sip_user_A | regex_replace('-', '%2d') }}.dat"
+jibri_outbound_sip_user_B: sipjibrioutb
+jibri_outbound_sip_path_B: "/var/lib/prosody/{{ jibri_outbound_sip_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_outbound_sip_user_B | regex_replace('-', '%2d') }}.dat"

--- a/ansible/roles/jibri-auth/defaults/main.yml
+++ b/ansible/roles/jibri-auth/defaults/main.yml
@@ -31,3 +31,10 @@ jibri_brewery_path_A: "/var/lib/prosody/{{ jibri_brewery_domain | regex_replace(
 jibri_brewery_username_B: jibrib
 jibri_brewery_path_B: "/var/lib/prosody/{{ jibri_brewery_domain | regex_replace('\\.', '%2e') |
   regex_replace('-', '%2d') }}/accounts/{{ jibri_brewery_username_B | regex_replace('-', '%2d') }}.dat"
+jibri_selenium_domain: "recorder.{{ prosody_domain_name }}"
+jibri_selenium_user_A: jibria
+jibri_selenium_path_A: "/var/lib/prosody/{{ jibri_selenium_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_username_A | regex_replace('-', '%2d') }}.dat"
+jibri_selenium_user_B: jibrib
+jibri_selenium_path_B: "/var/lib/prosody/{{ jibri_selenium_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jibri_selenium_username_B | regex_replace('-', '%2d') }}.dat"

--- a/ansible/roles/jibri-auth/tasks/main.yml
+++ b/ansible/roles/jibri-auth/tasks/main.yml
@@ -30,3 +30,17 @@
   args:
     creates: "{{ jibri_auth_prosody_jvb_domain_path }}"
   when: prosody_jvb_configure_flag and jibri_auth_password and jibri_auth_password != 'replaceme'
+
+- name: Add jibri account A for XMPP brewery
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_brewery_username_A }}@{{ jibri_brewery_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_brewery_A }}\n{{ secrets_jibri_brewery_A }}"
+    creates: "{{ jibri_brewery_path_A }}"
+  when: secrets_jibri_brewery_A is defined and secrets_jibri_brewery_A and secrets_jibri_brewery_A != ""
+
+- name: Add jibri account B for XMPP brewery
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_brewery_username_B }}@{{ jibri_brewery_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_brewery_B }}\n{{ secrets_jibri_brewery_B }}"
+    creates: "{{ jibri_brewery_path_B }}"
+  when: secrets_jibri_brewery_B is defined and secrets_jibri_brewery_B and secrets_jibri_brewery_B != ""

--- a/ansible/roles/jibri-auth/tasks/main.yml
+++ b/ansible/roles/jibri-auth/tasks/main.yml
@@ -44,3 +44,17 @@
     stdin: "{{ secrets_jibri_brewery_B }}\n{{ secrets_jibri_brewery_B }}"
     creates: "{{ jibri_brewery_path_B }}"
   when: secrets_jibri_brewery_B is defined and secrets_jibri_brewery_B and secrets_jibri_brewery_B != ""
+
+- name: Add jibri account A for selenium
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_selenium_user_A }}@{{ jibri_selenium_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_selenium_A }}\n{{ secrets_jibri_selenium_A }}"
+    creates: "{{ jibri_selenium_path_A }}"
+  when: secrets_jibri_selenium_A is defined and secrets_jibri_selenium_A and secrets_jibri_selenium_A != ""
+
+- name: Add jibri account B for selenium
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_selenium_user_B }}@{{ jibri_selenium_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_selenium_B }}\n{{ secrets_jibri_selenium_B }}"
+    creates: "{{ jibri_selenium_path_B }}"
+  when: secrets_jibri_selenium_B is defined and secrets_jibri_selenium_B and secrets_jibri_selenium_B != ""

--- a/ansible/roles/jibri-auth/tasks/main.yml
+++ b/ansible/roles/jibri-auth/tasks/main.yml
@@ -3,21 +3,25 @@
   ansible.builtin.command: prosodyctl register {{ jibri_auth_user }} {{ jibri_auth_domain }} {{ jibri_auth_password }}
   args:
     creates: "{{ jibri_auth_domain_path }}"
+  when: jibri_legacy_auth and jibri_auth_password and jibri_auth_password != 'replaceme'
 
 - name: Add jibri selenium authentication
   ansible.builtin.command: prosodyctl register {{ jibri_selenium_auth_user }} {{ jibri_selenium_auth_domain }} {{ jibri_selenium_auth_password }}
   args:
     creates: "{{ jibri_selenium_auth_domain_path }}"
+  when: jibri_legacy_auth and jibri_selenium_auth_password and jibri_selenium_auth_password != 'replaceme'
 
 - name: Add outbound-sip-jibri authentication
   ansible.builtin.command: prosodyctl register {{ outbound_sip_jibri_auth_user }} {{ outbound_sip_jibri_auth_domain }} {{ outbound_sip_jibri_auth_password }}
   args:
     creates: "{{ outbound_sip_jibri_auth_domain_path }}"
+  when: jibri_legacy_auth and outbound_sip_jibri_auth_password and outbound_sip_jibri_auth_password != 'replaceme'
 
 - name: Add inbound-sip-jibri authentication
   ansible.builtin.command: prosodyctl register {{ inbound_sip_jibri_auth_user }} {{ inbound_sip_jibri_auth_domain }} {{ inbound_sip_jibri_auth_password }}
   args:
     creates: "{{ inbound_sip_jibri_auth_domain_path }}"
+  when: jibri_legacy_auth and inbound_sip_jibri_auth_password and inbound_sip_jibri_auth_password != 'replaceme'
 
 # prosody-jvb
 - name: Add jibri authentication for prosody-jvb
@@ -25,4 +29,4 @@
     {{ jibri_auth_user }} {{ jibri_prosody_jvb_auth_domain_name }} {{ jibri_auth_password }}
   args:
     creates: "{{ jibri_auth_prosody_jvb_domain_path }}"
-  when: prosody_jvb_configure_flag
+  when: prosody_jvb_configure_flag and jibri_auth_password and jibri_auth_password != 'replaceme'

--- a/ansible/roles/jibri-auth/tasks/main.yml
+++ b/ansible/roles/jibri-auth/tasks/main.yml
@@ -58,3 +58,17 @@
     stdin: "{{ secrets_jibri_selenium_B }}\n{{ secrets_jibri_selenium_B }}"
     creates: "{{ jibri_selenium_path_B }}"
   when: secrets_jibri_selenium_B is defined and secrets_jibri_selenium_B and secrets_jibri_selenium_B != ""
+
+- name: Add jibri account A for outbound sip
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_outbound_sip_user_A }}@{{ jibri_outbound_sip_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_outbound_sip_A }}\n{{ secrets_jibri_outbound_sip_A }}"
+    creates: "{{ jibri_outbound_sip_path_A }}"
+  when: secrets_jibri_outbound_sip_A is defined and secrets_jibri_outbound_sip_A and secrets_jibri_outbound_sip_A != ""
+
+- name: Add jibri account B for outbound sip
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_outbound_sip_user_B }}@{{ jibri_outbound_sip_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_outbound_sip_B }}\n{{ secrets_jibri_outbound_sip_B }}"
+    creates: "{{ jibri_outbound_sip_path_B }}"
+  when: secrets_jibri_outbound_sip_B is defined and secrets_jibri_outbound_sip_B and secrets_jibri_outbound_sip_B != ""

--- a/ansible/roles/jibri-auth/tasks/main.yml
+++ b/ansible/roles/jibri-auth/tasks/main.yml
@@ -72,3 +72,17 @@
     stdin: "{{ secrets_jibri_outbound_sip_B }}\n{{ secrets_jibri_outbound_sip_B }}"
     creates: "{{ jibri_outbound_sip_path_B }}"
   when: secrets_jibri_outbound_sip_B is defined and secrets_jibri_outbound_sip_B and secrets_jibri_outbound_sip_B != ""
+
+- name: Add jibri account A for inbound sip
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_inbound_sip_user_A }}@{{ jibri_inbound_sip_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_inbound_sip_A }}\n{{ secrets_jibri_inbound_sip_A }}"
+    creates: "{{ jibri_inbound_sip_path_A }}"
+  when: secrets_jibri_inbound_sip_A is defined and secrets_jibri_inbound_sip_A and secrets_jibri_inbound_sip_A != ""
+
+- name: Add jibri account B for inbound sip
+  ansible.builtin.command: prosodyctl adduser "{{ jibri_inbound_sip_user_B }}@{{ jibri_inbound_sip_domain }}"
+  args:
+    stdin: "{{ secrets_jibri_inbound_sip_B }}\n{{ secrets_jibri_inbound_sip_B }}"
+    creates: "{{ jibri_inbound_sip_path_B }}"
+  when: secrets_jibri_inbound_sip_B is defined and secrets_jibri_inbound_sip_B and secrets_jibri_inbound_sip_B != ""

--- a/ansible/roles/jigasi-auth/defaults/main.yml
+++ b/ansible/roles/jigasi-auth/defaults/main.yml
@@ -4,6 +4,17 @@ jigasi_auth_domain_path: "/var/lib/prosody/{{ jigasi_auth_domain | regex_replace
   regex_replace('-', '%2d') }}/accounts/{{ jigasi_auth_user }}.dat"
 jigasi_auth_password: "{{ jigasi_xmpp_password | default('replaceme') }}"
 jigasi_auth_user: "{{ jigasi_xmpp_jid_username }}"
+jigasi_brewery_domain: "auth.{{ prosody_domain_name }}"
+# Different than the legacy username because we want to provision new accounts.
+# Note: avoid capital letters and special chars because prosody lowers/encodes them in the filename.
+jigasi_brewery_username_A: "jigasia"
+jigasi_brewery_username_B: "jigasib"
+jigasi_brewery_path_A: "/var/lib/prosody/{{ jigasi_brewery_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jigasi_brewery_username_A }}.dat"
+jigasi_brewery_path_B: "/var/lib/prosody/{{ jigasi_brewery_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jigasi_brewery_username_B }}.dat"
+# Enable/disable provisioning jigasi accounts using the old variable names
+jigasi_legacy_auth: true
 jigasi_transcriber_auth_domain: "recorder.{{ prosody_domain_name }}"
 jigasi_transcriber_auth_domain_path: "/var/lib/prosody/{{ jigasi_transcriber_auth_domain | regex_replace('\\.', '%2e') |
   regex_replace('-', '%2d') }}/accounts/{{ jigasi_transcriber_auth_user }}.dat"

--- a/ansible/roles/jigasi-auth/defaults/main.yml
+++ b/ansible/roles/jigasi-auth/defaults/main.yml
@@ -20,3 +20,12 @@ jigasi_transcriber_auth_domain_path: "/var/lib/prosody/{{ jigasi_transcriber_aut
   regex_replace('-', '%2d') }}/accounts/{{ jigasi_transcriber_auth_user }}.dat"
 jigasi_transcriber_auth_password: "replaceme"
 jigasi_transcriber_auth_user: "transcriber"
+# Different than the legacy username because we want to provision new accounts.
+# Note: avoid capital letters and special chars because prosody lowers/encodes them in the filename.
+jigasi_transcriber_domain: "recorder.{{ prosody_domain_name }}"
+jigasi_transcriber_username_A: "transcribera"
+jigasi_transcriber_path_A: "/var/lib/prosody/{{ jigasi_transcriber_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jigasi_transcriber_username_A }}.dat"
+jigasi_transcriber_username_B: "transcriberb"
+jigasi_transcriber_path_B: "/var/lib/prosody/{{ jigasi_transcriber_domain | regex_replace('\\.', '%2e') |
+  regex_replace('-', '%2d') }}/accounts/{{ jigasi_transcriber_username_B }}.dat"

--- a/ansible/roles/jigasi-auth/tasks/main.yml
+++ b/ansible/roles/jigasi-auth/tasks/main.yml
@@ -24,3 +24,17 @@
     stdin: "{{ secrets_jigasi_brewery_B }}\n{{ secrets_jigasi_brewery_B }}"
     creates: "{{ jigasi_brewery_path_B }}"
   when: secrets_jigasi_brewery_B is defined and secrets_jigasi_brewery_B and secrets_jigasi_brewery_B != ""
+
+- name: Add jigasi account A for transcriber
+  ansible.builtin.command: prosodyctl adduser "{{ jigasi_transcriber_username_A }}@{{ jigasi_transcriber_domain }}"
+  args:
+    stdin: "{{ secrets_jigasi_transcriber_A }}\n{{ secrets_jigasi_transcriber_A }}"
+    creates: "{{ jigasi_transcriber_path_A }}"
+  when: secrets_jigasi_transcriber_A is defined and secrets_jigasi_transcriber_A and secrets_jigasi_transcriber_A != ""
+
+- name: Add jigasi account B for transcriber
+  ansible.builtin.command: prosodyctl adduser "{{ jigasi_transcriber_username_B }}@{{ jigasi_transcriber_domain }}"
+  args:
+    stdin: "{{ secrets_jigasi_transcriber_B }}\n{{ secrets_jigasi_transcriber_B }}"
+    creates: "{{ jigasi_transcriber_path_B }}"
+  when: secrets_jigasi_transcriber_B is defined and secrets_jigasi_transcriber_B and secrets_jigasi_transcriber_B != ""

--- a/ansible/roles/jigasi-auth/tasks/main.yml
+++ b/ansible/roles/jigasi-auth/tasks/main.yml
@@ -38,3 +38,33 @@
     stdin: "{{ secrets_jigasi_transcriber_B }}\n{{ secrets_jigasi_transcriber_B }}"
     creates: "{{ jigasi_transcriber_path_B }}"
   when: secrets_jigasi_transcriber_B is defined and secrets_jigasi_transcriber_B and secrets_jigasi_transcriber_B != ""
+
+- name: Add jitsi-shared-secret account for jigasi A
+  ansible.builtin.blockinfile:
+    path: /etc/prosody/prosody.cfg.lua
+    marker: "-- {mark} ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi A"
+    block: |
+      VirtualHost "jigasia.{{ prosody_domain_name }}"
+        modules_enabled = {
+      {% if prosody_xmpp_resume is not defined or prosody_xmpp_resume %}
+      "smacks";
+      {% endif %}
+      }
+      authentication = "jitsi-shared-secret"
+      shared_secret = "{{ secrets_jigasi_conference_A }}"
+  when: secrets_jigasi_conference_A is defined and secrets_jigasi_conference_A and secrets_jigasi_conference_A != ""
+
+- name: Add jitsi-shared-secret account for jigasi B
+  ansible.builtin.blockinfile:
+    path: /etc/prosody/prosody.cfg.lua
+    marker: "-- {mark} ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi B"
+    block: |
+      VirtualHost "jigasib.{{ prosody_domain_name }}"
+        modules_enabled = {
+      {% if prosody_xmpp_resume is not defined or prosody_xmpp_resume %}
+      "smacks";
+      {% endif %}
+      }
+      authentication = "jitsi-shared-secret"
+      shared_secret = "{{ secrets_jigasi_conference_B }}"
+  when: secrets_jigasi_conference_B is defined and secrets_jigasi_conference_B and secrets_jigasi_conference_B != ""

--- a/ansible/roles/jigasi-auth/tasks/main.yml
+++ b/ansible/roles/jigasi-auth/tasks/main.yml
@@ -1,10 +1,26 @@
 ---
-- name: Add jigasi XMPP control authentication
+- name: Add legacy jigasi XMPP control authentication
   ansible.builtin.command: prosodyctl register {{ jigasi_auth_user }} {{ jigasi_auth_domain }} {{ jigasi_auth_password }}
   args:
     creates: "{{ jigasi_auth_domain_path }}"
+  when: jigasi_legacy_auth and jigasi_auth_password != 'replaceme'
 
-- name: Add jigasi transcriber authentication
+- name: Add legacy jigasi transcriber authentication
   ansible.builtin.command: prosodyctl register {{ jigasi_transcriber_auth_user }} {{ jigasi_transcriber_auth_domain }} {{ jigasi_transcriber_auth_password }}
   args:
     creates: "{{ jigasi_transcriber_auth_domain_path }}"
+  when: jigasi_legacy_auth and jigasi_transcriber_auth_password != 'replaceme'
+
+- name: Add jigasi account A for XMPP brewery
+  ansible.builtin.command: prosodyctl adduser "{{ jigasi_brewery_username_A }}@{{ jigasi_brewery_domain }}"
+  args:
+    stdin: "{{ secrets_jigasi_brewery_A }}\n{{ secrets_jigasi_brewery_A }}"
+    creates: "{{ jigasi_brewery_path_A }}"
+  when: secrets_jigasi_brewery_A is defined and secrets_jigasi_brewery_A and secrets_jigasi_brewery_A != ""
+
+- name: Add jigasi account B for XMPP brewery
+  ansible.builtin.command: prosodyctl adduser "{{ jigasi_brewery_username_B }}@{{ jigasi_brewery_domain }}"
+  args:
+    stdin: "{{ secrets_jigasi_brewery_B }}\n{{ secrets_jigasi_brewery_B }}"
+    creates: "{{ jigasi_brewery_path_B }}"
+  when: secrets_jigasi_brewery_B is defined and secrets_jigasi_brewery_B and secrets_jigasi_brewery_B != ""

--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -178,14 +178,22 @@ prosody_mod_turncredentials_secret: "{{ coturn_secret | default('secret') }}"
 prosody_muc_allowners: false
 prosody_muc_max_occupants: 21
 prosody_muc_max_occupants_ignore_list:
+  - "jibria@recorder.{{ prosody_domain_name }}"
+  - "jibrib@recorder.{{ prosody_domain_name }}"
   - "recorder@recorder.{{ prosody_domain_name }}"
   - "transcriber@recorder.{{ prosody_domain_name }}"
+  - "transcribera@recorder.{{ prosody_domain_name }}"
+  - "transcriberb@recorder.{{ prosody_domain_name }}"
 prosody_muc_moderated_rooms: false
 prosody_muc_moderated_subdomains: false
 prosody_muc_password_whitelist_jids:
   - "focus@{{ prosody_auth_domain_name }}"
+  - "jibria@recorder.{{ prosody_domain_name }}"
+  - "jibrib@recorder.{{ prosody_domain_name }}"
   - "recorder@recorder.{{ prosody_domain_name }}"
   - "transcriber@recorder.{{ prosody_domain_name }}"
+  - "transcribera@recorder.{{ prosody_domain_name }}"
+  - "transcriberb@recorder.{{ prosody_domain_name }}"
 prosody_muc_require_token_for_moderation: false
 # prosody 0.11 and later should always use epoll for scalability
 prosody_network_backend: epoll

--- a/ansible/roles/prosody/files/mod_muc_events.lua
+++ b/ansible/roles/prosody/files/mod_muc_events.lua
@@ -63,7 +63,7 @@ local jwtKeyCache = require"util.cache".new(jwtKeyCacheSize);
 
 -- option to ignore events about the focus and other components
 local blacklistPrefixes
-    = module:get_option_array("muc_events_blacklist_prefixes", {'focus@auth.','recorder@recorder.','jvb@auth.','jibri@auth.','transcriber@recorder.'});
+    = module:get_option_array("muc_events_blacklist_prefixes", {'focus@auth.','recorder@recorder.','recordera@recorder.','recorderb@','jvb@auth.','jibri@auth.','jibria@auth.','jibrib@auth.','transcriber@recorder.', 'transcribera@recorder.', 'transcriberb@recorder.'});
 
 local eventURL
     = module:get_option_string("muc_events_url", 'http://127.0.0.1:9880/');

--- a/ansible/roles/prosody/files/util.internal.lib.lua
+++ b/ansible/roles/prosody/files/util.internal.lib.lua
@@ -15,7 +15,7 @@ if not muc_domain_base then
     muc_domain_base = ""
 end
 
-local blacklist_prefix = module:get_option_array("muc_events_blacklist_prefixes", { 'focus@auth.', 'recorder@recorder.', 'jvb@auth.', 'jibri@auth.', 'transcriber@recorder.', 'jigasi@auth.' });
+local blacklist_prefix = module:get_option_array("muc_events_blacklist_prefixes", { 'focus@auth.', 'recorder@recorder.','recordera@recorder', 'recorderb@recorder', 'jvb@auth.', 'jibri@auth.','jibri@auth.','jibrib@auth.', 'transcriber@recorder.','transcribera@recorder.','transcriberb@recorder.', 'jigasi@auth.', 'jigasia@auth.','jigasib@auth.' });
 
 -- The "real" MUC domain that we are proxying to
 local muc_domain = module:get_option_string("muc_mapper_domain", muc_domain_prefix .. "." .. muc_domain_base);
@@ -45,8 +45,8 @@ else
     return
 end
 
-Util.OUTBOUND_SIP_JIBRI_PREFIX = 'outbound-sip-jibri@';
-Util.INBOUND_SIP_JIBRI_PREFIX = 'inbound-sip-jibri@';
+Util.OUTBOUND_SIP_JIBRI_PREFIXES = { 'outbound-sip-jibri@', 'sipjibriouta@', 'sipjibrioutb@' };
+Util.INBOUND_SIP_JIBRI_PREFIXES = { 'inbound-sip-jibri@', 'sipjibriina@', 'sipjibriinb@' };
 
 Util.FIRST_TRANSCRIPT_MESSAGE_POS = 1;
 
@@ -161,10 +161,10 @@ end
 local function get_sip_jibri_email_prefix(email)
     if not email then
         return nil;
-    elseif Util.has_prefix(email, Util.INBOUND_SIP_JIBRI_PREFIX) then
-        return Util.INBOUND_SIP_JIBRI_PREFIX;
-    elseif Util.has_prefix(email, Util.OUTBOUND_SIP_JIBRI_PREFIX) then
-        return Util.OUTBOUND_SIP_JIBRI_PREFIX;
+    elseif Util.starts_with_one_of(email, Util.INBOUND_SIP_JIBRI_PREFIXES) then
+        return Util.starts_with_one_of(INBOUND_SIP_JIBRI_PREFIXES);
+    elseif Util.starts_with_one_of(email, Util.OUTBOUND_SIP_JIBRI_PREFIXES) then
+        return Util.starts_with_one_of(OUTBOUND_SIP_JIBRI_PREFIXES);
     else
         return nil;
     end
@@ -211,6 +211,18 @@ function Util.has_prefix(str, prefix)
         return false;
     end
     return str:sub(1, #prefix) == prefix
+end
+
+function Util.starts_with_one_of(str, prefixes)
+    if not str then
+        return false;
+    end
+    for i=1,#prefixes do
+        if Util.has_prefix(str, prefixes[i]) then
+            return prefixes[i];
+        end
+    end
+    return false
 end
 
 local function extract_field_text(o, field, ns)

--- a/ansible/roles/prosody/files/util.internal.lib.lua
+++ b/ansible/roles/prosody/files/util.internal.lib.lua
@@ -16,6 +16,7 @@ if not muc_domain_base then
 end
 
 local blacklist_prefix = module:get_option_array("muc_events_blacklist_prefixes", { 'focus@auth.', 'recorder@recorder.','recordera@recorder', 'recorderb@recorder', 'jvb@auth.', 'jibri@auth.','jibri@auth.','jibrib@auth.', 'transcriber@recorder.','transcribera@recorder.','transcriberb@recorder.', 'jigasi@auth.', 'jigasia@auth.','jigasib@auth.' });
+local blacklist_domain_prefix = module:get_option_array("muc_events_blacklist_domain_prefixes", {'jigasia.', 'jigasib.' });
 
 -- The "real" MUC domain that we are proxying to
 local muc_domain = module:get_option_string("muc_mapper_domain", muc_domain_prefix .. "." .. muc_domain_base);
@@ -152,6 +153,13 @@ function Util.is_blacklisted(occupant)
     for _, prefix in ipairs(blacklist_prefix) do
         if string.sub(occupant_jid, 1, string.len(prefix)) == prefix then
             module:log("debug", "Occupant %s is blacklisted ", occupant_jid);
+            return true;
+        end
+    end
+    local occupant_domain = jid.host(occupant_jid);
+    for _, prefix in ipairs(blacklist_domain_prefix) do
+        if string.sub(occupant_domain, 1, string.len(prefix)) == prefix then
+            module:log("debug", "Occupant %s is blacklisted by domain", occupant_jid);
             return true;
         end
     end

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -787,7 +787,7 @@ VirtualHost "sipjibri.{{ prosody_domain_name }}"
 {% endif %}
 
 {% if secrets_jigasi_conference_A %}
-; BEGIN ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi A
+-- BEGIN ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi A
 VirtualHost "jigasia.{{ prosody_domain_name }}"
     modules_enabled = {
 {% if prosody_xmpp_resume %}
@@ -796,11 +796,11 @@ VirtualHost "jigasia.{{ prosody_domain_name }}"
     }
     authentication = "jitsi-shared-secret"
     shared_secret = "{{ secrets_jigasi_conference_A }}"
-; END ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi A
+-- END ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi A
 {% endif %}
 
 {% if secrets_jigasi_conference_B %}
-; BEGIN ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi B
+-- BEGIN ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi B
 VirtualHost "jigasib.{{ prosody_domain_name }}"
     modules_enabled = {
 {% if prosody_xmpp_resume %}
@@ -810,4 +810,4 @@ VirtualHost "jigasib.{{ prosody_domain_name }}"
     authentication = "jitsi-shared-secret"
     shared_secret = "{{ secrets_jigasi_conference_B }}"
 {% endif %}
-; END ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi B
+-- END ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi B

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -784,13 +784,10 @@ VirtualHost "sipjibri.{{ prosody_domain_name }}"
     }
     authentication = "jitsi-shared-secret"
     shared_secret = "{{ sip_jibri_shared_secrets[hcv_environment] }}"
-{% if prosody_xmpp_resume %}
-    -- this is dropped in 0.12
-    smacks_max_hibernated_sessions = 2000;
-{% endif %}
 {% endif %}
 
 {% if secrets_jigasi_conference_A %}
+; BEGIN ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi A
 VirtualHost "jigasia.{{ prosody_domain_name }}"
     modules_enabled = {
 {% if prosody_xmpp_resume %}
@@ -799,13 +796,11 @@ VirtualHost "jigasia.{{ prosody_domain_name }}"
     }
     authentication = "jitsi-shared-secret"
     shared_secret = "{{ secrets_jigasi_conference_A }}"
-{% if prosody_xmpp_resume %}
-    -- this is dropped in 0.12
-    smacks_max_hibernated_sessions = 2000;
-{% endif %}
+; END ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi A
 {% endif %}
 
 {% if secrets_jigasi_conference_B %}
+; BEGIN ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi B
 VirtualHost "jigasib.{{ prosody_domain_name }}"
     modules_enabled = {
 {% if prosody_xmpp_resume %}
@@ -814,8 +809,5 @@ VirtualHost "jigasib.{{ prosody_domain_name }}"
     }
     authentication = "jitsi-shared-secret"
     shared_secret = "{{ secrets_jigasi_conference_B }}"
-{% if prosody_xmpp_resume %}
-    -- this is dropped in 0.12
-    smacks_max_hibernated_sessions = 2000;
 {% endif %}
-{% endif %}
+; END ANSIBLE MANAGED BLOCK jitsi-shared-secret jigasi B

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -790,15 +790,30 @@ VirtualHost "sipjibri.{{ prosody_domain_name }}"
 {% endif %}
 {% endif %}
 
-{% if jigasi_xmpp_password %}
-VirtualHost "jigasi.{{ prosody_domain_name }}"
+{% if secrets_jigasi_conference_A %}
+VirtualHost "jigasia.{{ prosody_domain_name }}"
     modules_enabled = {
 {% if prosody_xmpp_resume %}
       "smacks";
 {% endif %}
     }
     authentication = "jitsi-shared-secret"
-    shared_secret = "{{ jigasi_xmpp_password }}"
+    shared_secret = "{{ secrets_jigasi_conference_A }}"
+{% if prosody_xmpp_resume %}
+    -- this is dropped in 0.12
+    smacks_max_hibernated_sessions = 2000;
+{% endif %}
+{% endif %}
+
+{% if secrets_jigasi_conference_B %}
+VirtualHost "jigasib.{{ prosody_domain_name }}"
+    modules_enabled = {
+{% if prosody_xmpp_resume %}
+      "smacks";
+{% endif %}
+    }
+    authentication = "jitsi-shared-secret"
+    shared_secret = "{{ secrets_jigasi_conference_B }}"
 {% if prosody_xmpp_resume %}
     -- this is dropped in 0.12
     smacks_max_hibernated_sessions = 2000;


### PR DESCRIPTION
- Provision new jigasi brewery accounts (A and B).
- Provision jitsi-shared-secret A and B accounts for jigasi.
- Provision accounts for jigasi transcriber (A and B).
- Put jibri account behind a flag, do not provision default ("replaceme") accounts.
- Provision jibri brewery accounts (A and B).
- Provision jibri selenium accounts (A and B).
- Provision jibri outbound sip XMPP accounts (A and B).
- Provision jibri inbound sip XMPP accounts (A and B).
- Add tasks to provision jitsi-shared-secret if missing.
- squash: Fix variable names.
