### PR TITLE
Provision new jicofo accounts, change variable names.

### DIFF
--- a/ansible/build-signal.yml
+++ b/ansible/build-signal.yml
@@ -9,7 +9,6 @@
   vars_files:
     - secrets/ssh-users.yml
     - secrets/jibri.yml
-    - secrets/jicofo.yml
     - secrets/repo.yml
     - secrets/prosody-egress-aws.yml
     - secrets/github-deploy.yml

--- a/ansible/build-signal.yml
+++ b/ansible/build-signal.yml
@@ -9,6 +9,7 @@
   vars_files:
     - secrets/ssh-users.yml
     - secrets/jibri.yml
+    - secrets/jicofo.yml
     - secrets/repo.yml
     - secrets/prosody-egress-aws.yml
     - secrets/github-deploy.yml

--- a/ansible/configure-core-local.yml
+++ b/ansible/configure-core-local.yml
@@ -25,6 +25,7 @@
     - secrets/ssl-certificates.yml
     - secrets/prosody.yml
     - secrets/jibri.yml
+    - secrets/jicofo.yml
     - secrets/jigasi.yml
     - secrets/wavefront.yml
     - secrets/coturn.yml

--- a/ansible/configure-standalone.yml
+++ b/ansible/configure-standalone.yml
@@ -43,6 +43,7 @@
     - secrets/ssh-users.yml
     - secrets/ssl-certificates.yml
     - secrets/jibri.yml
+    - secrets/jicofo.yml
     - secrets/jigasi.yml
     - secrets/asap-keys.yml
     - secrets/coturn.yml

--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-jicofo_auth_domain: "auth.{{ prosody_domain_name | default(domain.local) }}"
-jicofo_auth_password: "{{ secrets_jicofo_focus | default(replaceme) }}"
-jicofo_auth_password_jvb: "{{ secrets_jicofo_focus_jvb | default(replaceme) }}"
-jicofo_auth_password_visitor: "{{ secrets_jicofo_focus_visitor | default(replaceme) }}"
+jicofo_auth_domain: "auth.{{ prosody_domain_name | default('domain.local') }}"
+jicofo_auth_password: "{{ secrets_jicofo_focus | default('replaceme') }}"
+jicofo_auth_password_jvb: "{{ secrets_jicofo_focus_jvb | default('replaceme') }}"
+jicofo_auth_password_visitor: "{{ secrets_jicofo_focus_visitor | default('replaceme') }}"
 jicofo_auth_type: XMPP
 jicofo_auth_url: "{{ prosody_domain_name }}"
 jicofo_auth_url_enable: false
@@ -35,7 +35,7 @@ jicofo_health_cron:
   minute: "*"
 jicofo_health_cron_user: ubuntu
 jicofo_health_script_path: /usr/local/bin/jicofo-health.sh
-jicofo_hostname: "{{ prosody_domain_name | default(domain.local) }}"
+jicofo_hostname: "{{ prosody_domain_name | default('domain.local') }}"
 jicofo_install_flag: true
 jicofo_internal_muc_prefix: "{{ internal_muc_prefix | default('internal.auth') }}"
 jicofo_jibri_brewery_muc: JibriBrewery@{{ jicofo_internal_muc_prefix }}.{{ prosody_domain_name }}

--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -46,7 +46,6 @@ jicofo_max_audio_senders: 999999
 jicofo_max_bridge_participants: 80
 jicofo_max_memory: "1536m"
 jicofo_max_video_senders: 999999
-jicofo_opts: ""
 jicofo_prosody_jvb_hostname: "127.0.0.1"
 jicofo_prosody_jvb_port: 6222
 jicofo_prosody_brewery_shard_enabled: "{{ prosody_brewery_shard_enabled | default(true) }}"

--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-jicofo_auth_domain: auth.domain.local
-jicofo_auth_password: replaceme
-jicofo_auth_password_jvb: replaceme
-jicofo_auth_password_visitor: replaceme
+jicofo_auth_domain: "auth.{{ prosody_domain_name | default(domain.local) }}"
+jicofo_auth_password: "{{ secrets_jicofo_focus | default(replaceme) }}"
+jicofo_auth_password_jvb: "{{ secrets_jicofo_focus_jvb | default(replaceme) }}"
+jicofo_auth_password_visitor: "{{ secrets_jicofo_focus_visitor | default(replaceme) }}"
 jicofo_auth_type: XMPP
 jicofo_auth_url: "{{ prosody_domain_name }}"
 jicofo_auth_url_enable: false
@@ -35,7 +35,7 @@ jicofo_health_cron:
   minute: "*"
 jicofo_health_cron_user: ubuntu
 jicofo_health_script_path: /usr/local/bin/jicofo-health.sh
-jicofo_hostname: domain.local
+jicofo_hostname: "{{ prosody_domain_name | default(domain.local) }}"
 jicofo_install_flag: true
 jicofo_internal_muc_prefix: "{{ internal_muc_prefix | default('internal.auth') }}"
 jicofo_jibri_brewery_muc: JibriBrewery@{{ jicofo_internal_muc_prefix }}.{{ prosody_domain_name }}

--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 jicofo_auth_domain: auth.domain.local
 jicofo_auth_password: replaceme
+jicofo_auth_password_jvb: replaceme
+jicofo_auth_password_visitor: replaceme
 jicofo_auth_type: XMPP
 jicofo_auth_url: "{{ prosody_domain_name }}"
 jicofo_auth_url_enable: false

--- a/ansible/roles/jicofo/templates/config.j2
+++ b/ansible/roles/jicofo/templates/config.j2
@@ -1,19 +1,3 @@
-# Jitsi Conference Focus settings
-# sets the XMPP domain (default: none)
-JICOFO_HOSTNAME="{{ jicofo_hostname }}"
-
-# sets the XMPP domain name to use for XMPP user logins
-JICOFO_AUTH_DOMAIN="{{ jicofo_auth_domain }}"
-
-# sets the username to use for XMPP user logins
-JICOFO_AUTH_USER="{{ jicofo_auth_user }}"
-
-# sets the password to use for XMPP user logins
-JICOFO_AUTH_PASSWORD="{{ jicofo_auth_password }}"
-
-# extra options to pass to the jicofo daemon
-JICOFO_OPTS="{{ jicofo_opts }}"
-
 # adds java system props that are passed to jicofo (default are for home and logging config file)
 JAVA_SYS_PROPS="-Dnet.java.sip.communicator.SC_HOME_DIR_LOCATION=/etc/jitsi -Dnet.java.sip.communicator.SC_HOME_DIR_NAME=jicofo -Dnet.java.sip.communicator.SC_LOG_DIR_LOCATION=/var/log/jitsi -Djava.util.logging.config.file=/etc/jitsi/jicofo/logging.properties -Dconfig.file=/etc/jitsi/jicofo/jicofo.conf"
 

--- a/ansible/roles/jicofo/templates/jicofo.conf.j2
+++ b/ansible/roles/jicofo/templates/jicofo.conf.j2
@@ -145,8 +145,8 @@ jicofo {
     client {
       client-proxy = focus.{{ prosody_domain_name }}
       domain = {{ jicofo_auth_domain }}
-      username = {{ jicofo_auth_user }}
-      password = {{ jicofo_auth_password }}
+      username = "{{ jicofo_auth_user }}"
+      password = "{{ jicofo_auth_password }}"
       xmpp-domain = {{ jicofo_hostname }}
     }
 {% if jicofo_separate_jvb_muc %}
@@ -182,7 +182,7 @@ jicofo {
                 port = {{ 52220+i }}
                 domain = auth.meet.jitsi
                 xmpp-domain = v{{ i }}.meet.jitsi
-                password = {{ jicofo_auth_password_visitor }}
+                password = "{{ jicofo_auth_password_visitor }}"
                 disable-certificate-verification = true
             }
     {% endfor %}

--- a/ansible/roles/jicofo/templates/jicofo.conf.j2
+++ b/ansible/roles/jicofo/templates/jicofo.conf.j2
@@ -156,7 +156,7 @@ jicofo {
       port = {{ jicofo_prosody_jvb_port }}
       domain = "{{ prosody_jvb_auth_domain_name }}"
       username = "{{ jicofo_auth_user }}"
-      password = "{{ jicofo_auth_password }}"
+      password = "{{ jicofo_auth_password_jvb }}"
 {% if not jicofo_prosody_brewery_shard_enabled %}
       disable-certificate-verification = true
 {% endif %}
@@ -182,7 +182,7 @@ jicofo {
                 port = {{ 52220+i }}
                 domain = auth.meet.jitsi
                 xmpp-domain = v{{ i }}.meet.jitsi
-                password = {{ jicofo_auth_password }}
+                password = {{ jicofo_auth_password_visitor }}
                 disable-certificate-verification = true
             }
     {% endfor %}

--- a/ansible/roles/jicofo/vars/main.yml
+++ b/ansible/roles/jicofo/vars/main.yml
@@ -1,8 +1,0 @@
----
-jicofo_hostname: "{{ prosody_domain_name }}"
-jicofo_auth_domain: "auth.{{ prosody_domain_name }}"
-jicofo_auth_user: focus
-jicofo_auth_password: "{{ secrets_jicofo_focus }}"
-jicofo_auth_password_jvb: "{{ secrets_jicofo_focus_jvb }}"
-jicofo_auth_password_visitor: "{{ secrets_jicofo_focus_visitor }}"
-jicofo_make_jvb_checks: true

--- a/ansible/roles/jicofo/vars/main.yml
+++ b/ansible/roles/jicofo/vars/main.yml
@@ -2,5 +2,7 @@
 jicofo_hostname: "{{ prosody_domain_name }}"
 jicofo_auth_domain: "auth.{{ prosody_domain_name }}"
 jicofo_auth_user: focus
-jicofo_auth_password: "{{ prosody_focus_user_secret }}"
+jicofo_auth_password: "{{ secrets_jicofo_focus }}"
+jicofo_auth_password_jvb: "{{ secrets_jicofo_focus_jvb }}"
+jicofo_auth_password_visitor: "{{ secrets_jicofo_focus_visitor }}"
 jicofo_make_jvb_checks: true

--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -101,7 +101,9 @@ prosody_enable_wait_for_host: false
 # prosody_log_level: change 'info' to 'debug' for debug logs
 prosody_focus_admins:
   - "focus@{{ prosody_auth_domain_name }}"
-prosody_focus_user_secret: replaceme
+prosody_focus_secret: "{{ secrets_jicofo_focus }}"
+prosody_focus_jvb_secret: "{{ secrets_jicofo_focus_jvb }}"
+prosody_focus_visitor_secret: "{{ secrets_jicofo_focus_visitor }}"
 prosody_guest_domain_name: "guest.{{ prosody_domain_name }}"
 prosody_hide_all_rooms: true
 prosody_install_flag: true

--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -101,9 +101,9 @@ prosody_enable_wait_for_host: false
 # prosody_log_level: change 'info' to 'debug' for debug logs
 prosody_focus_admins:
   - "focus@{{ prosody_auth_domain_name }}"
-prosody_focus_secret: "{{ secrets_jicofo_focus }}"
-prosody_focus_jvb_secret: "{{ secrets_jicofo_focus_jvb }}"
-prosody_focus_visitor_secret: "{{ secrets_jicofo_focus_visitor }}"
+prosody_focus_secret: "{{ secrets_jicofo_focus | default(false) }}"
+prosody_focus_jvb_secret: "{{ secrets_jicofo_focus_jvb | default(false) }}"
+prosody_focus_visitor_secret: "{{ secrets_jicofo_focus_visitor | default(false) }}"
 prosody_guest_domain_name: "guest.{{ prosody_domain_name }}"
 prosody_hide_all_rooms: true
 prosody_install_flag: true

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -277,6 +277,13 @@
     state: directory
   loop: "{{ range(0, prosody_visitors_count | int, 1) | list }}"
 
+- name: Create the prosody visitor directory in /var/lib
+  ansible.builtin.file:
+    mode: 0750
+    path: "/var/lib/prosody-v{{ item }}"
+    state: directory
+  loop: "{{ range(0, prosody_visitors_count | int, 1) | list }}"
+
 - name: Build prosody.cfg.lua from template for visitor
   ansible.builtin.template:
     src: prosody.cfg.lua.visitor.j2

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -324,7 +324,7 @@
   ansible.builtin.command: prosodyctl --config /etc/prosody-v{{ item }}/prosody.cfg.lua adduser focus@auth.meet.jitsi
   args:
     stdin: "{{ prosody_focus_visitor_secret }}\n{{ prosody_focus_visitor_secret }}"
-    creates: /var/lib/prosody-v{{ item }}/auth%2meet%2jitsi/accounts/focus.dat
+    creates: /var/lib/prosody-v{{ item }}/auth%2emeet%2ejitsi/accounts/focus.dat
   loop: "{{ range(0, prosody_visitors_count | int, 1) | list }}"
   when: prosody_focus_visitor_secret is defined and prosody_focus_visitor_secret and prosody_focus_visitor_secret != "replaceme"
 

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -282,6 +282,8 @@
     mode: 0750
     path: "/var/lib/prosody-v{{ item }}"
     state: directory
+    group: prosody
+    owner: prosody
   loop: "{{ range(0, prosody_visitors_count | int, 1) | list }}"
 
 - name: Build prosody.cfg.lua from template for visitor

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -260,7 +260,7 @@
     prosodyctl --config /etc/prosody-jvb/prosody.cfg.lua adduser "focus@{{ prosody_jvb_auth_domain_name }}"
   args:
     stdin: "{{ prosody_focus_jvb_secret }}\n{{ prosody_focus_jvb_secret }}"
-    creates: /var/lib/prosody-jvb/auth.{{ prosody_domain_name | replace(".", "%2") }}/accounts/focus.dat
+    creates: /var/lib/prosody-jvb/auth.{{ prosody_domain_name | replace("\\.", "%2e") }}/accounts/focus.dat
   when: prosody_jvb_configure_flag and prosody_focus_jvb_secret is defined and prosody_focus_jvb_secret and prosody_focus_jvb_secret != "replaceme"
 
 - name: Install muc presence filter pfw rule

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -238,9 +238,11 @@
   notify: Reload prosody JVB
 
 - name: Register focus prosody user
-  ansible.builtin.command: prosodyctl register focus auth.{{ prosody_domain_name }} "{{ prosody_focus_user_secret }}"
+  ansible.builtin.command: prosodyctl adduser focus@auth.{{ prosody_domain_name }}
   args:
+    stdin: "{{ prosody_focus_user_secret }}\n{{ prosody_focus_user_secret }}"
     creates: /var/lib/prosody/auth.{{ prosody_domain_name | replace(".", "%2") }}/accounts/focus.dat
+  when: prosody_focus_user_secret is defined and prosody_focus_user_secret and prosody_focus_user_secret != "replaceme"
 
 - name: Check whether module mod_roster_command exists
   ansible.builtin.stat:
@@ -255,11 +257,11 @@
 
 - name: Register focus prosody-jvb user
   ansible.builtin.command: |
-    prosodyctl --config /etc/prosody-jvb/prosody.cfg.lua register focus {{ prosody_jvb_auth_domain_name }} \
-     "{{ prosody_focus_user_secret }}"
+    prosodyctl --config /etc/prosody-jvb/prosody.cfg.lua adduser "focus@{{ prosody_jvb_auth_domain_name }}"
   args:
+    stdin: "{{ prosody_focus_user_secret }}\n{{ prosody_focus_user_secret }}"
     creates: /var/lib/prosody-jvb/auth.{{ prosody_domain_name | replace(".", "%2") }}/accounts/focus.dat
-  when: prosody_jvb_configure_flag
+  when: prosody_jvb_configure_flag and prosody_focus_user_secret is defined and prosody_focus_user_secret and prosody_focus_user_secret != "replaceme"
 
 - name: Install muc presence filter pfw rule
   ansible.builtin.template:
@@ -319,10 +321,12 @@
     daemon_reload: true
 
 - name: Add jicofo user for visitors
-  ansible.builtin.command: prosodyctl --config /etc/prosody-v{{ item }}/prosody.cfg.lua register focus auth.meet.jitsi "{{ prosody_focus_user_secret }}"
+  ansible.builtin.command: prosodyctl --config /etc/prosody-v{{ item }}/prosody.cfg.lua adduser focus@auth.meet.jitsi
   args:
+    stdin: "{{ prosody_focus_user_secret }}\n{{ prosody_focus_user_secret }}"
     creates: /var/lib/prosody-v{{ item }}/auth%2meet%2jitsi/accounts/focus.dat
   loop: "{{ range(0, prosody_visitors_count | int, 1) | list }}"
+  when: prosody_focus_user_secret is defined and prosody_focus_user_secret and prosody_focus_user_secret != "replaceme"
 
 - name: Copy over the plugin for muc event reporting
   ansible.builtin.copy:

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -331,7 +331,7 @@
   ansible.builtin.command: prosodyctl --config /etc/prosody-v{{ item }}/prosody.cfg.lua adduser focus@auth.meet.jitsi
   args:
     stdin: "{{ prosody_focus_visitor_secret }}\n{{ prosody_focus_visitor_secret }}"
-    creates: /var/lib/prosody-v{{ item }}/auth%2emeet%2ejitsi/accounts/focus.dat
+    creates: "/var/lib/prosody-v{{ item }}/auth%2emeet%2ejitsi/accounts/focus.dat"
   loop: "{{ range(0, prosody_visitors_count | int, 1) | list }}"
   when: prosody_focus_visitor_secret is defined and prosody_focus_visitor_secret and prosody_focus_visitor_secret != "replaceme"
 

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -240,9 +240,9 @@
 - name: Register focus prosody user
   ansible.builtin.command: prosodyctl adduser focus@auth.{{ prosody_domain_name }}
   args:
-    stdin: "{{ prosody_focus_user_secret }}\n{{ prosody_focus_user_secret }}"
+    stdin: "{{ prosody_focus_secret }}\n{{ prosody_focus_secret }}"
     creates: /var/lib/prosody/auth.{{ prosody_domain_name | replace(".", "%2") }}/accounts/focus.dat
-  when: prosody_focus_user_secret is defined and prosody_focus_user_secret and prosody_focus_user_secret != "replaceme"
+  when: prosody_focus_secret is defined and prosody_focus_secret and prosody_focus_secret != "replaceme"
 
 - name: Check whether module mod_roster_command exists
   ansible.builtin.stat:
@@ -259,9 +259,9 @@
   ansible.builtin.command: |
     prosodyctl --config /etc/prosody-jvb/prosody.cfg.lua adduser "focus@{{ prosody_jvb_auth_domain_name }}"
   args:
-    stdin: "{{ prosody_focus_user_secret }}\n{{ prosody_focus_user_secret }}"
+    stdin: "{{ prosody_focus_jvb_secret }}\n{{ prosody_focus_jvb_secret }}"
     creates: /var/lib/prosody-jvb/auth.{{ prosody_domain_name | replace(".", "%2") }}/accounts/focus.dat
-  when: prosody_jvb_configure_flag and prosody_focus_user_secret is defined and prosody_focus_user_secret and prosody_focus_user_secret != "replaceme"
+  when: prosody_jvb_configure_flag and prosody_focus_jvb_secret is defined and prosody_focus_jvb_secret and prosody_focus_jvb_secret != "replaceme"
 
 - name: Install muc presence filter pfw rule
   ansible.builtin.template:
@@ -323,10 +323,10 @@
 - name: Add jicofo user for visitors
   ansible.builtin.command: prosodyctl --config /etc/prosody-v{{ item }}/prosody.cfg.lua adduser focus@auth.meet.jitsi
   args:
-    stdin: "{{ prosody_focus_user_secret }}\n{{ prosody_focus_user_secret }}"
+    stdin: "{{ prosody_focus_visitor_secret }}\n{{ prosody_focus_visitor_secret }}"
     creates: /var/lib/prosody-v{{ item }}/auth%2meet%2jitsi/accounts/focus.dat
   loop: "{{ range(0, prosody_visitors_count | int, 1) | list }}"
-  when: prosody_focus_user_secret is defined and prosody_focus_user_secret and prosody_focus_user_secret != "replaceme"
+  when: prosody_focus_visitor_secret is defined and prosody_focus_visitor_secret and prosody_focus_visitor_secret != "replaceme"
 
 - name: Copy over the plugin for muc event reporting
   ansible.builtin.copy:

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -241,7 +241,7 @@
   ansible.builtin.command: prosodyctl adduser focus@auth.{{ prosody_domain_name }}
   args:
     stdin: "{{ prosody_focus_secret }}\n{{ prosody_focus_secret }}"
-    creates: /var/lib/prosody/auth.{{ prosody_domain_name | replace(".", "%2") }}/accounts/focus.dat
+    creates: /var/lib/prosody/auth.{{ prosody_domain_name | replace("\\.", "%2e") }}/accounts/focus.dat
   when: prosody_focus_secret is defined and prosody_focus_secret and prosody_focus_secret != "replaceme"
 
 - name: Check whether module mod_roster_command exists

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
@@ -4,6 +4,8 @@ c2s_ports = { 52220 + {{ item }} }
 http_ports = { 52800 + {{ item }} }
 https_ports = { }
 
+data_path = "/var/lib/prosody-{{ item }}/"
+
 daemonize = true;
 
 -- we use a common jid for jicofo

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
@@ -4,7 +4,7 @@ c2s_ports = { 52220 + {{ item }} }
 http_ports = { 52800 + {{ item }} }
 https_ports = { }
 
-data_path = "/var/lib/prosody-{{ item }}/"
+data_path = "/var/lib/prosody-v{{ item }}/"
 
 daemonize = true;
 


### PR DESCRIPTION
- Use adduser instead of register.
- Remove unused options from /etc/jicofo/config.
- Use separate secrets for different jicofo accounts.
- fix: Fix visitor prosody data_path and account file.
- fix: Fix prosody-jvb account file path.
- fix: Fix prosody account file path.
- Create /var/lib/prosody-vX.
- fix: Fix visitor prosody data_path.
- Fix owner of prosody /var/lib dirs.
