### PR TITLE
fix: Fixes loading conference details.

### DIFF
--- a/ansible/roles/prosody/files/mod_muc_events.lua
+++ b/ansible/roles/prosody/files/mod_muc_events.lua
@@ -427,7 +427,7 @@ local function processEvent(type,event)
         who_jid = jid.join(node, main_domain, resource);
     end
 
-    local cdetails = loadConferenceDetails(event.room);
+    local cdetails = loadConferenceDetails(event.room.jid);
 
     local occupant_nick = event.occupant and event.occupant.nick;
     if type == "Joined" then


### PR DESCRIPTION
There were participant joined events with missing session_id.
