### PR TITLE
Use new A accounts for jibri and sip-jibri.

### DIFF
--- a/ansible/configure-jibri-java-local-oracle.yml
+++ b/ansible/configure-jibri-java-local-oracle.yml
@@ -24,12 +24,12 @@
     fluentd_jitsi_log_group_role: jibri
     fluentd_jitsi_cloudwatch_logs_enabled: "{{ jibri_enable_fluentd }}"
     consul_template_env:
-      JIBRI_USERNAME: "{{ jibri_xmpp_username }}"
-      JIBRI_PASSWORD: "{{ jibri_xmpp_password }}"
+      JIBRI_USERNAME: "{{ jibri_auth_control_user }}"
+      JIBRI_PASSWORD: "{{ jibri_auth_control_pass }}"
       JIBRI_MUC_NICKNAME: "{{ ansible_hostname }}"
       JIBRI_BREWERY: "{{ jibri_xmpp_room_name }}"
-      RECORDER_USERNAME: "{{ jibri_selenium_auth_user }}"
-      RECORDER_PASSWORD: "{{ jibri_selenium_auth_password }}"
+      RECORDER_USERNAME: "{{ jibri_auth_call_user }}"
+      RECORDER_PASSWORD: "{{ jibri_auth_call_pass }}"
       JIBRI_USAGE_TIMEOUT: "{{ jibri_max_usage | default(0) }}"
     consul_template_template_files:
       - src: roles/jibri-java/files/xmpp.conf.template

--- a/ansible/roles/jibri-java/defaults/main.yml
+++ b/ansible/roles/jibri-java/defaults/main.yml
@@ -7,6 +7,12 @@ jibri_asap_audience: "jibri-queue"
 jibri_asap_issuer: "jibri"
 jibri_asap_key_id: "{{ asap_key['id'] if asap_key['id'] is defined else 'default' }}"
 jibri_asap_key_path: "/etc/jitsi/jibri/asap.key"
+# Either "A", "B", or "legacy". Just used to select the correct username/password used for login.
+jibri_auth_type: "legacy"
+jibri_auth_call_user: "{{ 'jibria' if jibri_auth_type == 'A' else ('jibrib' if jibri_auth_type == 'B' else 'recorder') }}"
+jibri_auth_call_pass: "{{ secrets_jibri_selenium_A if jibri_auth_type == 'A' else (secrets_jibri_selenium_B if jibri_auth_type == 'B' else jibri_selenium_auth_password) }}"
+jibri_auth_control_user: "{{ 'jibria' if jibri_auth_type == 'A' else ('jibrib' if jibri_auth_type == 'B' else 'jibri') }}"
+jibri_auth_control_pass: "{{ secrets_jibri_brewery_A if jibri_auth_type == 'A' else (secrets_jibri_brewery_B if jibri_auth_type == 'B' else jibri_auth_password) }}"
 jibri_brewery_prefix: "{{ internal_muc_prefix | default('internal.auth') }}."
 jibri_brewery_prosody_jvb_prefix: "{{ internal_jvb_prosody_muc_prefix | default('muc.jvb') }}."
 # Whether or not any value in the call-status-checks block is overridden

--- a/ansible/roles/jibri-java/templates/xmpp.conf.j2
+++ b/ansible/roles/jibri-java/templates/xmpp.conf.j2
@@ -6,8 +6,8 @@ jibri.api.xmpp.environments = [
         xmpp-domain = "{{ jibri_config_hosts[env_key]['xmpp_domain'] }}"
         control-login {
             domain = "{{ jibri_jid_prefix }}{{ jibri_config_hosts[env_key]['xmpp_domain'] }}"
-            username = "{{ jibri_xmpp_username }}"
-            password = "{{ jibri_xmpp_password }}"
+            username = "{{ jibri_auth_control_user }}"
+            password = "{{ jibri_auth_control_pass }}"
             port = {{ jibri_config_hosts[env_key]['host_port'] if jibri_config_hosts[env_key]['host_port'] is defined else jibri_xmpp_port }}
         }
         control-muc {
@@ -17,8 +17,8 @@ jibri.api.xmpp.environments = [
         }
         call-login {
             domain = "{{ jibri_selenium_prefix }}{{ jibri_config_hosts[env_key]['xmpp_domain'] }}"
-            username = "{{ jibri_selenium_auth_user }}"
-            password = "{{ jibri_selenium_auth_password }}"
+            username = "{{ jibri_auth_call_user }}"
+            password = "{{ jibri_auth_call_pass }}"
         }
         strip-from-room-domain = "{{ jibri_conference_prefix }}"
         usage-timeout = "{{ jibri_config_hosts[env_key]['usage_timeout'] }} minutes"

--- a/ansible/roles/sip-jibri-sidecar/defaults/main.yml
+++ b/ansible/roles/sip-jibri-sidecar/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
-inbound_sip_jibri_xmpp_password: "{{ inbound_sip_jibri_auth_password }}"
-inbound_sip_jibri_xmpp_user: "{{ inbound_sip_jibri_auth_user }}"
-outbound_sip_jibri_xmpp_password: "{{ outbound_sip_jibri_auth_password }}"
-outbound_sip_jibri_xmpp_user: "{{ outbound_sip_jibri_auth_user }}"
+inbound_sip_jibri_xmpp_password: "{{ secrets_jibri_inbound_sip_A if sip_jibri_auth_type == 'A' else (secrets_jibri_inbound_sip_B if sip_jibri_auth_type == 'B' else inbound_sip_jibri_auth_password) }}"
+inbound_sip_jibri_xmpp_user: "{{ 'sipjibriina' if sip_jibri_auth_type == 'A' else ('sipjibriinb' if sip_jibri_auth_type == 'B' else inbound_sip_jibri_auth_user) }}"
+outbound_sip_jibri_xmpp_password: "{{ secrets_jibri_outbound_sip_A if sip_jibri_auth_type == 'A' else (secrets_jibri_outbound_sip_B if sip_jibri_auth_type == 'B' else outbound_sip_jibri_auth_password) }}"
+outbound_sip_jibri_xmpp_user: "{{ 'sipjibriouta' if sip_jibri_auth_type == 'A' else ('sipjibrioutb' if sip_jibri_auth_type == 'B' else outbound_sip_jibri_auth_user) }}"
+sip_jibri_auth_type: "A"
 sip_jibri_base_path: /opt/jitsi/sip-jibri-sidecar
 #use regexp to extract the last two octet of the IP address and use it as the component ID for the jibri
 sip_jibri_component_id: "{{ ansible_default_ipv4.address | regex_replace('^(?P<g1>\\d+).(?P<g2>\\d+).(?P<g3>\\d+).(?P<g4>\\d+)$', '\\g<g2>-\\g<g3>-\\g<g4>') }}"


### PR DESCRIPTION
The account to use (A, B or legacy) can be configured with
jibri_auth_type and sip_jibri_auth_type
