### PR TITLE
fix(visitors): Fixes meeting id in vnode events.

### DIFF
--- a/ansible/roles/prosody/files/mod_muc_events.lua
+++ b/ansible/roles/prosody/files/mod_muc_events.lua
@@ -798,4 +798,15 @@ function module.add_host(host_module)
     host_module:hook("muc-broadcast-presence", handleBroadcastPresence);
     host_module:hook("muc-room-destroyed", handleRoomDestroyed);
     host_module:hook("muc-room-created", roomCreated, -1); -- run always after muc_meeting_id
+    host_module:hook('jicofo-unlock-room', function(e)
+        local room = e.room;
+        if e.fmuc_fired then
+            -- Updates the meeting id if it changed on connecting vnode
+            local cdetails = loadConferenceDetails(room.jid);
+            if cdetails["session_id"] ~= room._data.meetingId then
+                cdetails["session_id"] = room._data.meetingId;
+                storeConferenceDetails(room.jid, cdetails);
+            end
+        end
+    end);
 end


### PR DESCRIPTION
First jicofo connects and we generate a new meeting_id, later we receive the connect message from the main prosody to setup the room and prepare it for visitors and it is when we receive the meeting_id of the main room.
Make sure we update it in already generated conference details.
