### PR TITLE
flip visitor flag

### DIFF
--- a/ansible/roles/prosody/files/mod_muc_events.lua
+++ b/ansible/roles/prosody/files/mod_muc_events.lua
@@ -655,6 +655,18 @@ local function handleOccupantPreJoin(event)
     end
 
     attachMachineUid(event);
+
+    if is_visitor_prosody then
+        local occupant, room, session, stanza = event.occupant, event.room, event.origin, event.stanza;
+        if session.jitsi_meet_context_user and session.jitsi_meet_context_user.id then
+            local flip_device_tag = stanza:get_child("flip_device");
+            if flip_device_tag and session.jitsi_meet_context_features.flip
+                and (session.jitsi_meet_context_features.flip == true
+                        or session.jitsi_meet_context_features.flip == "true") then
+                room._data.flip_participant_nick = occupant.nick;
+            end
+        end
+    end
 end
 
 -- used for jaas and vo


### PR DESCRIPTION
- fix: Skips json decoding/encoding of cached data on every access.
- feat: Detects flip flag on visitor prosodies and report it.
- feat: Detects flip participant is in main and handle password if one is set.
