### PR TITLE
feat(prosody): Adds option to ignore display name from jwt.

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -44,6 +44,7 @@ prosody_configure_flag: true
 prosody_disable_messaging: false
 prosody_disabled_modules: ["pubsub", "register"]
 prosody_disable_required_room_claim: false
+prosody_displayname_ignore_jwt_name: false
 prosody_domain_name: "{{ environment_domain_name | default('domain.local') }}"
 # version vars for url install method
 prosody_dpkg_base_name: prosody

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -163,6 +163,10 @@ allowner_issuers = { "jitsi" };
 asap_require_room_claim = false;
 {% endif %}
 
+{% if prosody_displayname_ignore_jwt_name %}
+ignore_jwt_name = true;
+{% endif %}
+
 {% if prosody_enable_shortlived_tokens %}
 short_lived_token = {
     issuer = "prosody";


### PR DESCRIPTION
This is for mod_muc_displayname.