### PR TITLE
Always explicitly specify JVB's bwe algorithm.

### DIFF
--- a/ansible/roles/jitsi-videobridge/templates/jvb.conf.j2
+++ b/ansible/roles/jitsi-videobridge/templates/jvb.conf.j2
@@ -206,11 +206,13 @@ jmt {
         bitrate-threshold = {{ jvb_loss_bitrate_threshold_kbps }} kbps
       }
     }
-{% if jvb_use_google_cc2_bwe %}
     estimator {
+{% if jvb_use_google_cc2_bwe %}
        engine = GoogleCc2
-    }
+{% else %}
+       engine = GoogleCc       
 {% endif %}
+    }
   }
 {% if jvb_skip_authentication_for_silence %}
   srtp {


### PR DESCRIPTION
So that deployments don't change behavior if we change the JVB's default.