### PR TITLE
feat(prosody): add muc_resource_validate module support

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -82,6 +82,8 @@ prosody_enable_muc_census: true
 prosody_enable_muc_domain_mapper: false
 prosody_enable_muc_password_whitelist: true
 prosody_enable_muc_rate_limit: true
+prosody_enable_muc_resource_validate: true
+prosody_muc_resource_validate_anonymous_strict: false
 prosody_enable_muc_size: false
 prosody_enable_password_preset: false
 prosody_enable_persistent_lobby: false

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -666,8 +666,14 @@ Component "conference.{{ prosody_domain_name }}" "muc"
         "muc_displayname";
         "muc_cleanup_backend_services";
         "muc_occupant_session";
+{% if prosody_enable_muc_resource_validate %}
+        "muc_resource_validate";
+{% endif %}
     }
 
+{% if prosody_enable_muc_resource_validate %}
+    anonymous_strict = {{ prosody_muc_resource_validate_anonymous_strict | lower }};
+{% endif %}
 {% if prosody_enable_rate_limit %}
     -- Max allowed join/login rate in events per second.
 	rate_limit_login_rate = {{ prosody_rate_limit_login_rate }};


### PR DESCRIPTION
Adds two ansible vars for the `muc_resource_validate` prosody module:

- `prosody_enable_muc_resource_validate` (default: `false`)
- `prosody_muc_resource_validate_anonymous_strict` (default: `false`)

Updates the prosody Jinja template to conditionally load the module and set `anonymous_strict`.