### PR TITLE
Revert "Remove prosody_meet_conf_duration_enabled flag (unused)."

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -152,6 +152,7 @@ prosody_max_number_outgoing_calls: 3
 prosody_meet_auth_vpaas_enabled: false
 prosody_meet_av_moderation_enabled: true
 prosody_meet_chat_history_url: false
+prosody_meet_conf_duration_enabled: true
 prosody_get_media_type: false
 prosody_meet_flip_enabled: false
 prosody_meet_moderator_enabled: false


### PR DESCRIPTION
Reverts jitsi/infra-configuration#896

The flag is actually used:

https://github.com/jitsi/infra-configuration/blob/15377e915480d577158716a9a230c443e9237139/ansible/roles/prosody/templates/prosody.cfg.lua.j2#L456