### PR TITLE
fix(jvb,coturn): escape bash array-length syntax in vnic template

### DIFF
--- a/ansible/roles/coturn/templates/secondary_vnic_all_configure_oracle.sh.j2
+++ b/ansible/roles/coturn/templates/secondary_vnic_all_configure_oracle.sh.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+{% raw %}
 
 # Copyright (c) 2018, Oracle and/or its affiliates.
 # The Universal Permissive License (UPL), Version 1.0
@@ -33,7 +34,9 @@ declare -r DEF_NS_FORMAT_BM='ons${nic}vl${vltag}'
 declare -r DEF_NS_FORMAT_VM='ons${nic}'
 declare -r MACVLAN_FORMAT='${iface}.${vltag}' # note awk script looks for this (max 15 chars)
 declare -r VLAN_FORMAT='${iface}v${vltag}'    # (max 15 chars)
+{% endraw %}
 declare -ir MTU={{ coturn_jumbo_frames | bool | ternary(9000, 1500) }}
+{% raw %}
 declare -r ADD='ADD'
 declare -r DELETE='DELETE'
 declare -r YES='YES'
@@ -1453,3 +1456,4 @@ else
   show='t'
 fi
 [ -z "$show" ] || oci_vcn_show
+{% endraw %}

--- a/ansible/roles/jitsi-videobridge/templates/secondary_vnic_all_configure_oracle.sh.j2
+++ b/ansible/roles/jitsi-videobridge/templates/secondary_vnic_all_configure_oracle.sh.j2
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+{% raw %}
 
 # Copyright (c) 2018, Oracle and/or its affiliates.
 # The Universal Permissive License (UPL), Version 1.0
@@ -33,7 +34,9 @@ declare -r DEF_NS_FORMAT_BM='ons${nic}vl${vltag}'
 declare -r DEF_NS_FORMAT_VM='ons${nic}'
 declare -r MACVLAN_FORMAT='${iface}.${vltag}' # note awk script looks for this (max 15 chars)
 declare -r VLAN_FORMAT='${iface}v${vltag}'    # (max 15 chars)
+{% endraw %}
 declare -ir MTU={{ jvb_jumbo_frames | bool | ternary(9000, 1500) }}
+{% raw %}
 declare -r ADD='ADD'
 declare -r DELETE='DELETE'
 declare -r YES='YES'
@@ -1453,3 +1456,4 @@ else
   show='t'
 fi
 [ -z "$show" ] || oci_vcn_show
+{% endraw %}


### PR DESCRIPTION
The secondary_vnic_all_configure_oracle.sh.j2 template contains many ${#ARRAY[@]} bash array-length expressions, which Jinja2 parses as the start of a comment block ({#...#}) and fails with "Missing end of comment tag". Wrap the bash content in {% raw %}...{% endraw %} around the single templated MTU line.