### PR TITLE
feat(jitsi-meet): add jitsi_meet_enable_virtual_background_v2 flag

### DIFF
--- a/ansible/roles/jitsi-meet/defaults/main.yml
+++ b/ansible/roles/jitsi-meet/defaults/main.yml
@@ -176,6 +176,7 @@ jitsi_meet_enable_turn_udp_jvb: false
 jitsi_meet_enable_userdirs: false
 jitsi_meet_enable_unsafe_room_warning: false
 jitsi_meet_enable_user_roles_based_on_token: false
+jitsi_meet_enable_virtual_background_v2: false
 jitsi_meet_enable_welcome_page: true
 jitsi_meet_enable_webhid_feature: true
 jitsi_meet_enable_xmpp_websockets: true

--- a/ansible/roles/jitsi-meet/templates/config.js.j2
+++ b/ansible/roles/jitsi-meet/templates/config.js.j2
@@ -503,6 +503,11 @@ var config = {
 {% if jitsi_meet_disable_iframe_api %}
     disableIframeAPI: true,
 {% endif %}
+{% if jitsi_meet_enable_virtual_background_v2 %}
+    virtualBackground: {
+        enableV2: true
+    },
+{% endif %}
 {% if jitsi_meet_show_chat_permissions_setting %}
     showChatPermissionsModeratorSetting: true,
 {% endif %}


### PR DESCRIPTION
## Summary
- Adds a new ansible variable `jitsi_meet_enable_virtual_background_v2` (default `false`) so sites can opt into the V2 (MediaPipe / WebGL) virtual background engine.
- When the var is true, `config.js.j2` emits `virtualBackground: { enableV2: true }`, which the jitsi-meet web client reads to switch to the V2 effect factory.
- Default remains V1 everywhere; only sites that explicitly set the var get V2.

Companion change:
- `infra-provisioning` PR: wires the same flag through the Nomad pack template.

## Test plan
- [ ] Provision a site with the var unset — verify `config.js` contains no `virtualBackground` block.
- [ ] Provision a site with the var set to true — verify `config.virtualBackground.enableV2 === true` in the rendered `config.js`.
