### PR TITLE
feat(prosody): drop Prosody 0.11 compatibility

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -3,9 +3,6 @@
 hcv_environment: all
 jitsi_meet_api_server_name: "signal-api-{{ prosody_domain_name }}"
 jitsi_meet_no_sharding: false
-# This check by default is false, but on configure time we check the installed version of jitsi-meet, whether the module
-# exist and if it is there we enable it in the client prosody config template
-mod_external_services_exists: false
 prosody_admins: "{{ prosody_focus_admins | list }}"
 prosody_amplitude_api_key: false
 prosody_apt_base_name: prosody
@@ -49,8 +46,6 @@ prosody_domain_name: "{{ environment_domain_name | default('domain.local') }}"
 # version vars for url install method
 prosody_dpkg_base_name: prosody
 prosody_dpkg_path: "/tmp/{{ prosody_package_filename }}"
-# Custom prosody version with some performance fixes
-# https://packages.prosody.im/debian/pool/main/p/prosody-0.11/prosody-0.11_1nightly112-1~bionic_amd64.deb
 prosody_dpkg_url: "https://packages.prosody.im/debian/pool/main/p/{{ prosody_package_name }}/{{ prosody_package_filename }}"
 prosody_egress_url: http://127.0.0.1:8062/v1/events
 prosody_egress_fallback_url: https://api-vo-pilot.cloudflare.jitsi.net/vpaas-event-acceptor/v1/forward
@@ -209,14 +204,11 @@ prosody_muc_password_whitelist_jids:
   - "transcribera@recorder.{{ prosody_domain_name }}"
   - "transcriberb@recorder.{{ prosody_domain_name }}"
 prosody_muc_require_token_for_moderation: false
-# prosody 0.11 and later should always use epoll for scalability
 prosody_network_backend: epoll
 # YOLO, reevaluate after the heat dissipates
 prosody_open_file_limit: 999999
 # config only used when prosody_install_from_apt is false (file install method)
 prosody_package_filename: "{{ prosody_package_name }}_{{ prosody_package_version }}.deb"
-# with apt install we use package name from apt variable: 'prosody'
-# with file install we use package name from dpkg variable: 'prosody-0.11'
 prosody_package_name: "{{ prosody_dpkg_base_name if not prosody_install_from_apt else prosody_apt_base_name }}"
 prosody_package_subversion: "5"
 

--- a/ansible/roles/prosody/tasks/configure.yml
+++ b/ansible/roles/prosody/tasks/configure.yml
@@ -236,16 +236,6 @@
     path: "{{ prosody_plugins_path }}/mod_muc_meeting_id.lua"
   register: muc_meeting_id_exists
 
-# TODO: cleanup, we probably no longer need this
-- name: Check whether module mod_external_services exists
-  ansible.builtin.stat:
-    path: /usr/lib/prosody/modules/mod_external_services.lua
-  register: stat_mod_external_services
-
-- name: Set mod_external_services fact
-  ansible.builtin.set_fact:
-    mod_external_services_exists: "{{ stat_mod_external_services.stat.exists }}"
-
 - name: Build prosody.cfg.lua from template
   ansible.builtin.template:
     src: prosody.cfg.lua.j2

--- a/ansible/roles/prosody/templates/prosody-jvb.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody-jvb.cfg.lua.j2
@@ -28,7 +28,7 @@ data_path = "/var/lib/prosody-jvb/"
 c2s_ports = { 6222 }
 console_ports = { 5583 }
 
--- Enable use of native prosody 0.11 support for epoll over select
+-- Enable epoll network backend for scalability
 network_backend = "epoll";
 -- Set the TCP backlog to 511 since the kernel rounds it up to the next power of 2: 512.
 -- This only applies to the epoll backend but it's harmless to set on the select one.

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -31,7 +31,7 @@ gc = {
 -- use_libevent = true;
 
 {% if prosody_network_backend %}
--- Enable use of native prosody 0.11 support for epoll over select
+-- Enable epoll network backend for scalability
 network_backend = "{{ prosody_network_backend }}";
 -- Set the TCP backlog to 511 since the kernel rounds it up to the next power of 2: 512.
 -- This only applies to the epoll backend but it's harmless to set on the select one.
@@ -73,11 +73,7 @@ modules_enabled = {
       "debug_traceback";
 {% endif %}
 {% if prosody_enable_mod_turncredentials %}
-    {% if mod_external_services_exists %}
       "external_services";
-    {% else %}
-      "turncredentials";
-    {% endif %}
       "turncredentials_http";
 {% endif %}
 {% if prosody_enable_firewall and prosody_disable_messaging %}
@@ -121,19 +117,9 @@ log_slow_events_threshold = {{ prosody_slow_events_threshold }};
 
 {% if prosody_enable_mod_turncredentials %}
 {% if prosody_mod_turncredentials_secret %}
-turncredentials_secret = "{{ prosody_mod_turncredentials_secret }}";
 external_service_secret = "{{ prosody_mod_turncredentials_secret }}";
 {% endif %}
 
-turncredentials = {
-  {% for turnhost in prosody_mod_turncredentials_hosts %}
-  { type = "stun", host = "{{ turnhost }}", port = "{{ prosody_mod_turncredentials_port }}" },
-  { type = "turn", host = "{{ turnhost }}", port = "{{ prosody_mod_turncredentials_port }}", transport = "udp" },
-{% if prosody_mod_turncredentials_enable_tcp %}
-  { type = "turns", host = "{{ turnhost }}", port = "{{ prosody_mod_turncredentials_port }}", transport = "tcp" },
-{% endif %}
-{% endfor %}
-};
 external_services = {
 {% for turnhost in prosody_mod_turncredentials_hosts %}
   { type = "stun", host = "{{ turnhost }}", port = {{ prosody_mod_turncredentials_port }}, transport = "udp" },

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.visitor.j2
@@ -29,7 +29,7 @@ admins = {
 }
 component_admins_as_room_owners = true;
 
--- Enable use of native prosody 0.11 support for epoll over select
+-- Enable epoll network backend for scalability
 network_backend = 'epoll';
 network_settings = {
   tcp_backlog = 511;
@@ -256,9 +256,7 @@ VirtualHost 'v{{ item }}.meet.jitsi'
     modules_enabled = {
       'bosh';
       'ping';
-    {% if mod_external_services_exists %}
       "external_services";
-    {% endif %}
     {% if prosody_xmpp_resume %}
       "smacks";
     {% endif %}


### PR DESCRIPTION
- Remove mod_external_services_exists runtime stat check; Prosody 13
  (the only supported version) always ships external_services built-in.
- Simplify prosody.cfg.lua.j2: always load external_services instead of
  the old turncredentials/external_services branch.
- Remove the legacy turncredentials_secret and turncredentials={} config
  block from prosody.cfg.lua.j2; keep external_service_secret and
  external_services={} which external_services requires.
- Remove the mod_external_services_exists conditional from the visitor
  config; external_services is now always enabled unconditionally.
- Clean up stale comments referencing Prosody 0.11.
