### PR TITLE
feat(prosody): add async_transcriber_type_map option

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -26,6 +26,8 @@ asap_key_shortlived:
 prosody_asap_key_path: /etc/prosody/certs/asap.key
 prosody_asap_shortlived_key_path: /etc/prosody/certs/asap-shortlived.key
 prosody_asap_shortlived_key: "{{ asap_key_shortlived[hcv_environment] if hcv_environment in asap_key_shortlived else asap_key_shortlived['default'] }}"
+# Map of tenant to async transcriber type override, used by mod_muc_password_preset.
+prosody_async_transcriber_type_map: {}
 prosody_auth_domain_name: "auth.{{ prosody_domain_name }}"
 prosody_bosh_max_inactivity: 60
 # assume shard has local prosody-jvb, otherwise use prosody-brewery shared service

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -202,6 +202,15 @@ prosody_password_public_key_repo_url = "{{ prosody_password_public_key_repo_url 
 {% endif %}
 {% endif %}
 
+{% if prosody_async_transcriber_type_map %}
+-- Map of tenant to async transcriber type override, used by mod_muc_password_preset.
+async_transcriber_type_map = {
+{% for tenant, transcriber_type in prosody_async_transcriber_type_map.items() %}
+    ["{{ tenant }}"] = "{{ transcriber_type }}";
+{% endfor %}
+};
+{% endif %}
+
 {% if prosody_visitors_queue_service_url %}
 visitors_queue_service = '{{ prosody_visitors_queue_service_url }}'
 {% endif %}


### PR DESCRIPTION
Adds a configurable tenant-to-transcriber-type map, rendered into the
Prosody config and consumed by mod_muc_password_preset to override the
async transcriber type per tenant.
