### PR TITLE
feat: Add jitsi_meet_render_transcript_details flag for config.js

### DIFF
--- a/ansible/roles/jitsi-meet/defaults/main.yml
+++ b/ansible/roles/jitsi-meet/defaults/main.yml
@@ -234,6 +234,7 @@ jitsi_meet_recordings_require_consent: false
 jitsi_meet_recordings_consent_learn_more_url: ''
 jitsi_meet_recordings_skip_consent_in_meeting: false
 jitsi_meet_redirect_to_ssl: true
+jitsi_meet_render_transcript_details: false
 jitsi_meet_require_displayname: false
 jitsi_meet_resolution: false
 jitsi_meet_resolution_force_aspect_ratio: false

--- a/ansible/roles/jitsi-meet/templates/config.js.j2
+++ b/ansible/roles/jitsi-meet/templates/config.js.j2
@@ -241,7 +241,8 @@ var config = {
         enabled: {% if jitsi_meet_enable_transcription %}true{% else %}false{% endif %},
         translationEnabled: {% if jitsi_meet_enable_transcription_translation %}true{% else %}false{% endif %},
         disableClosedCaptions: {% if jitsi_meet_enable_transcription %}false{% else %}true{% endif %},
-        inviteJigasiOnBackendTranscribing: {% if jitsi_meet_transcription_disable_jigasi %}false{% else %}true{% endif %}
+        inviteJigasiOnBackendTranscribing: {% if jitsi_meet_transcription_disable_jigasi %}false{% else %}true{% endif %},
+        renderTranscriptDetails: {% if jitsi_meet_render_transcript_details %}true{% else %}false{% endif %}
     },
     recordings: {
         suggestRecording: {% if jitsi_meet_recordings_prompt %}true{% else %}false{% endif %},


### PR DESCRIPTION
Adds a `jitsi_meet_render_transcript_details` flag (default `false`) that controls `transcription.renderTranscriptDetails` in config.js.