### PR TITLE
feat(jenkins): add jenkins_root_url for Cloudflare-fronted canonical URL

### DIFF
--- a/ansible/roles/jenkins/defaults/main.yml
+++ b/ansible/roles/jenkins/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 jenkins_sitename: "jenkins-opsdev.jitsi.net"
+# Canonical/public URL used as the Jenkins root URL (drives UI links and the
+# SAML Assertion Consumer Service URL). Defaults to the origin sitename; override
+# per-site to front Jenkins behind a different public hostname (e.g. Cloudflare).
+jenkins_root_url: "https://{{ jenkins_sitename }}"
 jenkins_ssl_certificate: "{{ jitsi_net_ssl_certificate }}{{ jitsi_net_ssl_extras }}"
 jenkins_ssl_dest_dir: /etc/nginx/ssl
 jenkins_ssl_key_name: "{{ jitsi_net_ssl_key_name }}"

--- a/ansible/roles/jenkins/templates/casc-saml.yaml.j2
+++ b/ansible/roles/jenkins/templates/casc-saml.yaml.j2
@@ -1,3 +1,9 @@
+unclassified:
+  location:
+    # Canonical root URL drives the SAML Assertion Consumer Service URL
+    # (<url>/securityRealm/finishLogin). Set explicitly so it does not depend
+    # on the baked-in casc.yaml's handling of the JENKINS_URL env var.
+    url: "{{ jenkins_root_url }}"
 jenkins:
   securityRealm:
     saml:

--- a/ansible/roles/jenkins/templates/jenkins.service.j2
+++ b/ansible/roles/jenkins/templates/jenkins.service.j2
@@ -9,7 +9,7 @@ ExecStartPre=-/usr/bin/docker create -m 0b -p 8080:8080 -p 50000:50000 \
   --add-host=host.docker.internal:host-gateway \
   --privileged \
   --env DOCKER_TLS_CERTDIR=/certs \
-  --env JENKINS_URL=https://{{ jenkins_sitename }} \
+  --env JENKINS_URL={{ jenkins_root_url }} \
 {% if jenkins_saml_enabled | default(false) %}
   --env CASC_JENKINS_CONFIG=/home/jenkins/casc.yaml,/home/jenkins/secrets/casc-saml.yaml \
   --env SAML_DISPLAY_NAME_ATTR={{ jenkins_saml_display_name_attr | default('http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name') }} \


### PR DESCRIPTION
## Summary

Decouples the canonical/public Jenkins URL from the origin hostname so the SAML login flow can target a Cloudflare-fronted host without VPN/internal routing.

- `jenkins_sitename` stays the **origin identity** → nginx `server_name` + TLS cert (`*.jitsi.net`), which is what the Cloudflare tunnel connects to. Unchanged.
- New `jenkins_root_url` is the **canonical/public URL** → Jenkins root URL, which drives UI links and the SAML Assertion Consumer Service URL (`<url>/securityRealm/finishLogin`). Defaults to `https://{{ jenkins_sitename }}`, so opsdev/standalone behavior is unchanged.

### Why
The Jenkins SAML plugin derives the ACS URL from the root URL and validates the SAML Response `Destination`/`Recipient` against it — there is no independent ACS override. So to land the IdP callback on a Cloudflare host, the SP's root URL must be that host. Keeping `jenkins_sitename` separate means agents and the origin TLS are untouched.

### Changes
- `defaults/main.yml`: new `jenkins_root_url`
- `jenkins.service.j2`: `JENKINS_URL` sourced from `jenkins_root_url`
- `casc-saml.yaml.j2`: explicit `unclassified.location.url` so the ACS is deterministic regardless of the baked image's `JENKINS_URL` handling

### Companion change
Site overrides (`jenkins_root_url` for ops-prod/ops-dev + cloudprober synthetic) are in a separate PR against `infra-customizations-private`.

### Out-of-repo follow-up (required for login to work)
- Update the Oracle IDCS SP app: ACS URL **and** SP Entity ID/Audience → `https://jenkins-ops.cloudflare.jitsi.net/securityRealm/finishLogin` (dev → opsdev host).
- Ensure the Cloudflare tunnel routes the cloudflare hostname to the origin and allows the SAML POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)