### PR TITLE
feat(vector): route logs through Alloy OTEL Loki receiver instead of direct Loki

### DIFF
--- a/ansible/roles/vector/defaults/main.yml
+++ b/ansible/roles/vector/defaults/main.yml
@@ -5,7 +5,13 @@ vector_cloud_instance_id: "{{ cloud_instance_id | default('default') }}"
 vector_cloud_region: "{{ oracle_region }}"
 vector_configure_flag: true
 vector_install_flag: true
-vector_loki_url: "https://{{ hcv_environment}}-{{oracle_region }}-loki.{{ top_level_domain }}"
+# By default vector routes logs through the Alloy OTEL collector's Loki push API,
+# which forwards on to the regional Loki. Set vector_route_direct_to_loki: true to
+# bypass Alloy and write to Loki directly.
+vector_route_direct_to_loki: false
+vector_direct_loki_url: "https://{{ hcv_environment }}-{{ oracle_region }}-loki.{{ top_level_domain }}"
+vector_alloy_loki_url: "https://{{ hcv_environment }}-{{ oracle_region }}-otel-loki.{{ top_level_domain }}"
+vector_loki_url: "{{ vector_direct_loki_url if vector_route_direct_to_loki else vector_alloy_loki_url }}"
 vector_shard_name: "{{ shard_name }}"
 vector_shard_role: "{{ shard_role | default('vector') }}"
 vector_nginx_enabled: false

--- a/ansible/roles/vector/templates/vector.yaml.j2
+++ b/ansible/roles/vector/templates/vector.yaml.j2
@@ -109,6 +109,10 @@ sources:
             strategy: device_and_inode
 {% endif %}
 sinks:
+  # NOTE: healthcheck is intentionally disabled on every loki sink below.
+  # With healthchecks enabled, vector refuses to start if the loki endpoint is
+  # unreachable at boot. That failure propagates up through the ansible boot
+  # process and fails provisioning, churning otherwise-functional nodes.
   loki_syslog:
     remove_timestamp: false
     type: "loki"


### PR DESCRIPTION
## Summary

Pivots Vector to write logs to the new Alloy OTEL Loki receiver instead of directly to the regional Loki, matching the nomad-vector approach in `infra-provisioning`.

Vector keeps its `loki`-type sinks but their endpoint now points at the Alloy collector's Loki push API (`<env>-<region>-otel-loki.<domain>`). Alloy's `loki.source.api "vector"` receiver forwards on to both the internal regional Loki and external Loki, so this removes Vector's direct/local-Loki output (Alloy writes there now).

## Changes

- **`ansible/roles/vector/defaults/main.yml`**: `vector_loki_url` now defaults to the Alloy `otel-loki` endpoint. Because every sink in the template already references `vector_loki_url`, repointing this single var redirects all outputs at once. A `vector_route_direct_to_loki` flag preserves the old behavior — mirroring the `VECTOR_ROUTE_DIRECT_TO_LOKI` toggle in `deploy-nomad-vector.sh`.
- **`ansible/roles/vector/templates/vector.yaml.j2`**: documents why healthchecks stay disabled on the loki sinks — an unreachable endpoint at boot fails vector startup, which fails the ansible boot process and churns otherwise-functional nodes. Especially relevant now that the endpoint is the Alloy collector.

## Reference

- `infra-provisioning/scripts/deploy-nomad-vector.sh`
- `infra-provisioning/nomad/vector.hcl`
- `infra-provisioning/nomad/alloy.hcl` (the `loki.source.api "vector"` receiver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)