### PR TITLE
fix(jenkins): remove duplicate unclassified.location.url from SAML casc

### DIFF
--- a/ansible/roles/jenkins/templates/casc-saml.yaml.j2
+++ b/ansible/roles/jenkins/templates/casc-saml.yaml.j2
@@ -1,9 +1,3 @@
-unclassified:
-  location:
-    # Canonical root URL drives the SAML Assertion Consumer Service URL
-    # (<url>/securityRealm/finishLogin). Set explicitly so it does not depend
-    # on the baked-in casc.yaml's handling of the JENKINS_URL env var.
-    url: "{{ jenkins_root_url }}"
 jenkins:
   securityRealm:
     saml:


### PR DESCRIPTION
## Problem

After #921 merged, Jenkins fails to boot:

```
io.jenkins.plugins.casc.ConfiguratorConflictException: Found conflicting configuration at
YamlSource: /home/jenkins/secrets/casc-saml.yaml, line 6, column 10
  url: "https://jenkins-opsdev.cloudfla ...
```

The baked-in `/home/jenkins/casc.yaml` (loaded first in `CASC_JENKINS_CONFIG`) **already** defines `unclassified.location.url` from `${JENKINS_URL}`. JCasC's default `ErrorOnConflictMergeStrategy` rejects a second definition of the same key, so the explicit block #921 added to `casc-saml.yaml` is fatal.

## Fix

Remove the redundant `unclassified.location` block. The `JENKINS_URL` env var — now sourced from `jenkins_root_url` — already drives the root URL and therefore the SAML ACS (`<url>/securityRealm/finishLogin`) via the baked casc. No functional loss.

## Note

The conflict itself confirms the baked casc consumes `JENKINS_URL` for the location URL, so the canonical-URL behavior from #921 is preserved through the env var alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)