### PR TITLE
feat(jicofo): add jibri busy-retries config

### DIFF
--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -51,6 +51,10 @@ jicofo_internal_muc_prefix: "{{ internal_muc_prefix | default('internal.auth') }
 jicofo_jibri_brewery_muc: JibriBrewery@{{ jicofo_internal_muc_prefix }}.{{ environment_domain_name }}
 # Note the units are seconds
 jicofo_jibri_pending_timeout: 90
+# When all Jibris are busy, retry selection this many extra times before failing. 0 disables (fail immediately).
+jicofo_jibri_busy_retries: 0
+# Note the units are seconds. How long to wait between busy retries (only used when busy_retries > 0).
+jicofo_jibri_busy_retry_delay: 5
 jicofo_jigasi_brewery_muc: JigasiBrewery@{{ jicofo_internal_muc_prefix }}.{{ environment_domain_name }}
 jicofo_jvb_brewery_muc: JvbBrewery@{{ jicofo_internal_muc_prefix }}.{{ environment_domain_name }}
 jicofo_max_audio_senders: 999999

--- a/ansible/roles/jicofo/templates/jicofo.conf.j2
+++ b/ansible/roles/jicofo/templates/jicofo.conf.j2
@@ -126,6 +126,10 @@ jicofo {
     brewery-jid = "{{ jicofo_jibri_brewery_muc }}"
 {% endif %}
     pending-timeout = {{ jicofo_jibri_pending_timeout }} seconds
+{% if jicofo_jibri_busy_retries | int > 0 %}
+    busy-retries = {{ jicofo_jibri_busy_retries }}
+    busy-retry-delay = {{ jicofo_jibri_busy_retry_delay }} seconds
+{% endif %}
   }
 
 {% if jicofo_jigasi_brewery_muc %}


### PR DESCRIPTION
## What

Adds two new properties to the ansible-rendered jicofo `jibri` config block:

- `jicofo_jibri_busy_retries` (default `0` = off)
- `jicofo_jibri_busy_retry_delay` (default `5`, seconds)

When `busy-retries > 0`, the `jicofo.conf` jibri block renders `busy-retries` / `busy-retry-delay`; otherwise nothing is emitted and jicofo uses its built-in default (off). This preserves current behavior by default.

## Why

When all Jibri instances are momentarily busy (e.g. a demand spike at the top of the hour while the autoscaler spins up more, or two requests racing for the last free instance), jicofo currently fails the recording start immediately. The new jicofo `busy-retries` feature (jitsi/jicofo#1288) lets it wait briefly for the pool to free up instead.

## Related

- jicofo change: jitsi/jicofo#1288
- nomad/docker wiring for the nomad-deployed shards is handled in companion PRs (infra-provisioning + docker-jitsi-meet). This PR covers the ansible-deployed jicofo path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)