### PR TITLE
feat(jibri): make single-use-mode configurable per environment

### DIFF
--- a/ansible/roles/jibri-java/defaults/main.yml
+++ b/ansible/roles/jibri-java/defaults/main.yml
@@ -70,6 +70,10 @@ jibri_service_version_shell: "{{ jibri_service_version_shell_new if jibri_new_ve
 jibri_service_version_shell_new: "dpkg -s {{ jibri_deb_pkg_name }} | grep Version | awk '{print $2}' | cut -d'-' -f1,2,3"
 jibri_service_version_shell_old: "dpkg -s {{ jibri_deb_pkg_name }} | grep Version | awk '{print $2}' | cut -d'-' -f1 | cut -d'.' -f3"
 jibri_sidecar_webhook: false
+# When true (default) jibri goes to EXPIRED after a single recording/stream so the
+# instance is recycled. Set false (e.g. in stage-8x8) to return jibri to IDLE/ready
+# after each use, allowing the same instance to be reused.
+jibri_single_use_mode: true
 jibri_status_cron:
   hour: "*"
   job: "{{ jibri_path_to_status_script }} > /tmp/status-cron-output 2>&1"

--- a/ansible/roles/jibri-java/templates/jibri.conf.j2
+++ b/ansible/roles/jibri-java/templates/jibri.conf.j2
@@ -1,5 +1,5 @@
 jibri {
-    single-use-mode = true
+    single-use-mode = {{ jibri_single_use_mode | bool | lower }}
     id = "{{ jibri_nick }}"
     recording {
         recordings-directory = "{{ jibri_recordings_dir }}"


### PR DESCRIPTION
## Summary
Makes Jibri's `single-use-mode` configurable instead of hardcoded `true`.

With `single-use-mode = true` (today's behavior), a Jibri transitions to `EXPIRED` after a single recording/stream and the instance is recycled. Setting it `false` returns the Jibri to `IDLE`/ready after each use, so the same instance can be reused.

## Changes
- `jibri.conf.j2`: `single-use-mode = {{ jibri_single_use_mode | bool | lower }}`
- `defaults/main.yml`: new `jibri_single_use_mode: true` (no behavior change by default)

## Per-environment rollout
The companion override setting `jibri_single_use_mode: false` for **stage-8x8** lives in infra-customizations-private (separate PR).

## Notes
- stage-8x8 runs the autoscaler jibri sidecar (`autoscaler_sidecar_jibri_flag: true`); with reuse enabled, instances stay alive between jobs rather than being torn down per-job. Worth confirming the autoscaler's idle scale-down behaves as expected.