### PR TITLE
feat(jibri): match ChromeDriver to installed Chrome and validate at build

### DIFF
--- a/ansible/roles/chromedriver/defaults/main.yml
+++ b/ansible/roles/chromedriver/defaults/main.yml
@@ -1,8 +1,22 @@
 ---
+# By default, match ChromeDriver to the Chrome already installed on the host.
+# This lets us run the latest stable Chrome (installed via the google-chrome
+# role) and always pair it with a compatible ChromeDriver of the same major
+# version, which is ChromeDriver's compatibility contract.
+chromedriver_match_installed_chrome: true
+chromedriver_chrome_binary: /usr/bin/google-chrome
+
+# Chrome-for-Testing endpoints. The milestone endpoint is keyed by Chrome major
+# version and returns the matching ChromeDriver download; the last-known-good
+# endpoint is the fallback used when no installed Chrome can be detected.
+chromedriver_milestone_downloads_url: https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json
 chromedriver_latest_release_url: https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json
+chromedriver_use_latest: true
+
+# Optional hard pin. When set (e.g. "144.0.7559.132"), this exact ChromeDriver
+# version is installed and auto-detection is skipped.
+chromedriver_pin_version: ""
+
 chromedriver_path: /usr/bin/chromedriver
 chromedriver_tmp_dir: /tmp/chromedriver_linux64
 chromedriver_tmp_path: /tmp/chromedriver_linux64.zip
-chromedriver_url: https://storage.googleapis.com/chrome-for-testing-public/{{ chromedriver_version }}/linux64/chromedriver-linux64.zip
-chromedriver_use_latest: true
-chromedriver_version: 144.0.7559.132

--- a/ansible/roles/chromedriver/tasks/main.yml
+++ b/ansible/roles/chromedriver/tasks/main.yml
@@ -1,22 +1,107 @@
 ---
-- name: Grab latest chromedriver version string
+# Resolve which ChromeDriver to install. Precedence:
+#   1. Explicit pin (chromedriver_pin_version)
+#   2. Match the major version of the Chrome installed on this host
+#   3. Fall back to the Chrome-for-Testing "Stable" channel last-known-good
+# The download url/version land in chromedriver_url / chromedriver_version.
+
+- name: Use explicitly pinned ChromeDriver version
+  ansible.builtin.set_fact:
+    chromedriver_version: "{{ chromedriver_pin_version }}"
+    chromedriver_url: "https://storage.googleapis.com/chrome-for-testing-public/{{ chromedriver_pin_version }}/linux64/chromedriver-linux64.zip"
+  when: chromedriver_pin_version | length > 0
+
+# --- match installed Chrome ------------------------------------------------
+- name: Detect installed Google Chrome version
+  ansible.builtin.command: "{{ chromedriver_chrome_binary }} --version"
+  register: chromedriver_chrome_version_result
+  changed_when: false
+  failed_when: false
+  when:
+    - chromedriver_url is not defined
+    - chromedriver_match_installed_chrome
+
+- name: Set installed Chrome major version fact
+  ansible.builtin.set_fact:
+    chromedriver_chrome_major_version: "{{ chromedriver_chrome_version_result.stdout | regex_search('([0-9]+)\\.', '\\1') | first }}"
+  when:
+    - chromedriver_url is not defined
+    - chromedriver_match_installed_chrome
+    - chromedriver_chrome_version_result.rc == 0
+
+- name: Grab Chrome-for-Testing versions per milestone
+  ansible.builtin.uri:
+    url: "{{ chromedriver_milestone_downloads_url }}"
+    return_content: true
+  register: chromedriver_milestone_result
+  when: chromedriver_chrome_major_version is defined
+
+- name: Set ChromeDriver version and url from the matching Chrome milestone
+  ansible.builtin.set_fact:
+    chromedriver_milestone: "{{ (chromedriver_milestone_result.content | from_json).milestones[chromedriver_chrome_major_version] }}"
+  when:
+    - chromedriver_chrome_major_version is defined
+    - chromedriver_chrome_major_version in (chromedriver_milestone_result.content | from_json).milestones
+
+- name: Resolve ChromeDriver download from milestone
+  ansible.builtin.set_fact:
+    chromedriver_version: "{{ chromedriver_milestone.version }}"
+    chromedriver_url: "{{ chromedriver_milestone.downloads.chromedriver | selectattr('platform', 'equalto', 'linux64') | map(attribute='url') | first }}"
+  when: chromedriver_milestone is defined
+
+# --- guard / fallback: Stable channel last-known-good ----------------------
+# Reached when the installed Chrome's major has no CfT milestone yet (apt
+# briefly ahead of Chrome-for-Testing). Fall back to the latest CfT-covered
+# Stable driver; the jibri build-time session test (validate-chrome.yml) is the
+# final arbiter and fails the build if the pair is actually incompatible.
+- name: Warn that installed Chrome major has no matching CfT milestone
+  ansible.builtin.debug:
+    msg: >-
+      No Chrome-for-Testing milestone found for installed Chrome major
+      '{{ chromedriver_chrome_major_version | default("unknown") }}'. Falling back
+      to the latest CfT Stable ChromeDriver; build-time validation will verify
+      compatibility.
+  when:
+    - chromedriver_url is not defined
+    - chromedriver_match_installed_chrome
+
+- name: Grab latest chromedriver version string (Stable channel fallback)
   ansible.builtin.uri:
     url: "{{ chromedriver_latest_release_url }}"
     return_content: true
   register: chromedriver_version_result
-  when: chromedriver_use_latest
+  when:
+    - chromedriver_url is not defined
+    - chromedriver_use_latest
 
 - name: Set chromedriver details fact
   ansible.builtin.set_fact:
     chromedriver_details: "{{ chromedriver_version_result.content | from_json }}"
-  when: chromedriver_use_latest
+  when:
+    - chromedriver_url is not defined
+    - chromedriver_use_latest
 
-- name: Set chromedriver version fact
+- name: Set chromedriver version fact from Stable channel
   ansible.builtin.set_fact:
     chromedriver_version: "{{ chromedriver_details['channels']['Stable']['version'] }}"
     chromedriver_url: "{{ chromedriver_details | json_query('channels.Stable.downloads.chromedriver[?platform==`linux64`].url') | first }}"
-  when: chromedriver_use_latest
+  when:
+    - chromedriver_url is not defined
+    - chromedriver_details is defined
 
+- name: Fail if no ChromeDriver download could be resolved
+  ansible.builtin.fail:
+    msg: >-
+      Could not resolve a ChromeDriver download. Install Chrome before this role
+      (chromedriver_match_installed_chrome), set chromedriver_pin_version, or
+      enable chromedriver_use_latest.
+  when: chromedriver_url is not defined
+
+- name: Show selected ChromeDriver version
+  ansible.builtin.debug:
+    msg: "Installing ChromeDriver {{ chromedriver_version }} from {{ chromedriver_url }}"
+
+# --- download & install -----------------------------------------------------
 - name: Download chromedriver from google
   ansible.builtin.get_url:
     mode: 0644

--- a/ansible/roles/jibri-java/defaults/main.yml
+++ b/ansible/roles/jibri-java/defaults/main.yml
@@ -20,6 +20,9 @@ jibri_brewery_prosody_jvb_prefix: "{{ internal_jvb_prosody_muc_prefix | default(
 # variables should be added here.
 jibri_call_status_checks_overridden: "{{ true if jibri_all_muted_timeout_override else false }}"
 jibri_chrome_binary_path: /usr/bin/google-chrome
+# Port used by the transient ChromeDriver started during image build to
+# validate the Chrome/ChromeDriver combination (see tasks/validate-chrome.yml).
+jibri_chrome_validation_port: 9515
 jibri_cloud_provider: "{{ cloud_provider | default('aws') }}"
 # use regexp to extract the last two octet of the IP address and use it as the component ID for the jibri
 jibri_component_id: "{{ ansible_default_ipv4.address | regex_replace('^(?P<g1>\\d+).(?P<g2>\\d+).(?P<g3>\\d+).(?P<g4>\\d+)$', '\\g<g2>-\\g<g3>-\\g<g4>') }}"

--- a/ansible/roles/jibri-java/meta/main.yml
+++ b/ansible/roles/jibri-java/meta/main.yml
@@ -12,6 +12,8 @@ galaxy_info:
         - jammy
 dependencies:
   - { role: jitsi-repo, when: jibri_install_flag }
-  - { role: chromedriver, when: jibri_install_flag }
+  # google-chrome must precede chromedriver: the chromedriver role matches the
+  # ChromeDriver major version to the Chrome that is already installed.
   - { role: google-chrome, when: jibri_install_flag}
+  - { role: chromedriver, when: jibri_install_flag }
   - { role: openjdk-java, when: jibri_install_flag }

--- a/ansible/roles/jibri-java/tasks/install.yml
+++ b/ansible/roles/jibri-java/tasks/install.yml
@@ -1,4 +1,10 @@
 ---
+# Chrome and ChromeDriver are installed via this role's meta dependencies
+# (google-chrome, chromedriver) before these tasks run. Validate the pair is
+# compatible before building the image, failing fast on a bad combination.
+- name: Validate Chrome and ChromeDriver compatibility
+  ansible.builtin.include_tasks: validate-chrome.yml
+
 - name: Install additional fonts for jibri rendering
   ansible.builtin.apt:
     name: fonts-noto

--- a/ansible/roles/jibri-java/tasks/validate-chrome.yml
+++ b/ansible/roles/jibri-java/tasks/validate-chrome.yml
@@ -1,0 +1,99 @@
+---
+# Validate that the installed Chrome and ChromeDriver are compatible before
+# baking them into a jibri image. A major-version mismatch produces a runtime
+# SessionNotCreatedException ("This version of ChromeDriver only supports
+# Chrome version NNN") which silently breaks recording/streaming, so we fail
+# the build here rather than ship a broken image.
+
+- name: Get installed Google Chrome version
+  ansible.builtin.command: google-chrome --version
+  register: jibri_chrome_version_raw
+  changed_when: false
+
+- name: Get installed ChromeDriver version
+  ansible.builtin.command: chromedriver --version
+  register: jibri_chromedriver_version_raw
+  changed_when: false
+
+- name: Parse Chrome and ChromeDriver major versions
+  ansible.builtin.set_fact:
+    jibri_chrome_major_version: "{{ jibri_chrome_version_raw.stdout | regex_search('([0-9]+)\\.', '\\1') | first }}"
+    jibri_chromedriver_major_version: "{{ jibri_chromedriver_version_raw.stdout | regex_search('([0-9]+)\\.', '\\1') | first }}"
+
+- name: Assert Chrome and ChromeDriver major versions match
+  ansible.builtin.assert:
+    that:
+      - jibri_chrome_major_version == jibri_chromedriver_major_version
+    fail_msg: >-
+      Chrome ({{ jibri_chrome_version_raw.stdout }}) and ChromeDriver
+      ({{ jibri_chromedriver_version_raw.stdout }}) major versions do not match
+      ({{ jibri_chrome_major_version }} != {{ jibri_chromedriver_major_version }}).
+      Aborting image build to avoid releasing a jibri image with an
+      incompatible Chrome/ChromeDriver combination.
+    success_msg: >-
+      Chrome and ChromeDriver major versions match (v{{ jibri_chrome_major_version }}).
+
+# Beyond matching version strings, actually drive ChromeDriver to launch a
+# headless Chrome session. This reproduces the exact code path jibri exercises
+# and is the definitive check that the pair works together.
+- name: End-to-end validate Chrome/ChromeDriver session creation
+  block:
+    - name: Start ChromeDriver for validation
+      ansible.builtin.command: chromedriver --port={{ jibri_chrome_validation_port }}
+      async: 120
+      poll: 0
+      changed_when: false
+      register: jibri_chromedriver_validation_proc
+
+    - name: Wait for ChromeDriver to become ready
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ jibri_chrome_validation_port }}/status"
+        return_content: true
+      register: jibri_chromedriver_status
+      until: jibri_chromedriver_status.status == 200 and (jibri_chromedriver_status.json.value.ready | default(false))
+      retries: 10
+      delay: 2
+
+    - name: Attempt to create a headless Chrome session
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ jibri_chrome_validation_port }}/session"
+        method: POST
+        body_format: json
+        body:
+          capabilities:
+            alwaysMatch:
+              browserName: chrome
+              "goog:chromeOptions":
+                args:
+                  - "--headless=new"
+                  - "--no-sandbox"
+                  - "--disable-gpu"
+                  - "--disable-dev-shm-usage"
+        status_code: 200
+      register: jibri_chrome_session
+
+    - name: Confirm a session id was returned
+      ansible.builtin.assert:
+        that:
+          - jibri_chrome_session.json.value.sessionId is defined
+        fail_msg: >-
+          ChromeDriver did not return a valid session id; the Chrome/ChromeDriver
+          combination is broken. Aborting image build.
+        success_msg: >-
+          ChromeDriver successfully started a headless Chrome session.
+  always:
+    - name: Delete the validation session if one was created
+      ansible.builtin.uri:
+        url: "http://127.0.0.1:{{ jibri_chrome_validation_port }}/session/{{ jibri_chrome_session.json.value.sessionId }}"
+        method: DELETE
+        status_code: [200, 404]
+      when:
+        - jibri_chrome_session is defined
+        - jibri_chrome_session.json is defined
+        - jibri_chrome_session.json.value.sessionId is defined
+      failed_when: false
+
+    - name: Stop the validation ChromeDriver process
+      ansible.builtin.command: "pkill -f 'chromedriver --port={{ jibri_chrome_validation_port }}'"
+      changed_when: false
+      failed_when: false

--- a/ansible/roles/selenium-grid/meta/main.yml
+++ b/ansible/roles/selenium-grid/meta/main.yml
@@ -1,9 +1,11 @@
 ---
 dependencies:
 - { role: openjdk-java, when: selenium_grid_install_flag }
+# google-chrome must precede chromedriver: chromedriver matches its major
+# version to the Chrome already installed.
+- { role: google-chrome, google_chrome_beta_flag: true }
 # not used if extras is used
 - { role: chromedriver, when: selenium_grid_install_flag }
-- { role: google-chrome, google_chrome_beta_flag: true }
 - { role: firefox, firefox_beta_flag: true, when: selenium_grid_install_flag }
 # not used if extras is used
 - { role: geckodriver, when: selenium_grid_install_flag }


### PR DESCRIPTION
## Problem

Jibri images shipped with a ChromeDriver pinned to a fixed version (`144.0.7559.132`) while `google-chrome-stable` installs `state=latest`. The two drift apart, producing the runtime failure:

```
org.openqa.selenium.SessionNotCreatedException: Could not start a new session.
Response code 500. Message: session not created: This version of ChromeDriver
only supports Chrome version 150
```

This silently breaks recording/streaming on affected images.

## Approach

Make the **installed Chrome** the source of truth and pair ChromeDriver to it, then verify the combination before the image is built.

### `chromedriver` role
- Install `google-chrome` first, detect its **major** version, and fetch the matching ChromeDriver from Chrome-for-Testing's [`latest-versions-per-milestone-with-downloads.json`](https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone-with-downloads.json) (keyed by major — the compatibility contract).
- **Guard/fallback:** if the installed Chrome's major has no CfT milestone yet (apt briefly ahead of CfT), fall back to the latest CfT Stable driver and let build-time validation decide. Logs a clear warning.
- Optional hard pin via `chromedriver_pin_version` for break-glass.
- Removed the stale `chromedriver_version: 144.x` default pin.

### Meta dependency order
- `google-chrome` now precedes `chromedriver` in `jibri-java` and `selenium-grid` (jitsi-torture already correct), so the driver matches the Chrome just installed.

### Build-time validation (`jibri-java/tasks/validate-chrome.yml`)
Runs only during image build (`jibri_install_flag`), after both are installed:
1. Asserts Chrome and ChromeDriver **major versions match**.
2. Starts ChromeDriver and drives a real **headless Chrome session** over the WebDriver protocol — reproducing the exact path that throws `SessionNotCreatedException`. A bad pair aborts the build instead of being released. `block`/`always` guarantees the test session and ChromeDriver process are cleaned up.

## Why not "hold Chrome back to the latest CfT-covered major"?

Investigated and rejected: Google's apt repo only serves the **current** `google-chrome-stable` (older majors are pruned from the `.deb` pool — confirmed 404s), and CfT actually runs **ahead** of apt stable. So apt's Chrome is essentially always CfT-milestone-covered, and a held-back install isn't reliably achievable via the apt package anyway. Matching the driver to the installed Chrome + the build-time session test covers the real failure mode.

## Test plan
- [ ] Build a jibri image (`build-java-jibri-oracle.yml`) and confirm the validation tasks pass with a matched pair.
- [ ] Manually skew the versions (e.g. set `chromedriver_pin_version` to a mismatched major) and confirm the build **fails** at the validation step.