### PR TITLE
fix(boot): pre-clean conflicting ops-repo apt source before apt update (JIT-15930)

### DIFF
--- a/ansible/configure-consul-server-local-oracle.yml
+++ b/ansible/configure-consul-server-local-oracle.yml
@@ -34,6 +34,10 @@
     rsyslog_tcp_output_enabled: true
 
   pre_tasks:
+    # Must run before the apt cache update below: clears a conflicting
+    # trusted=yes/signed-by ops-repo source that would fail apt (JIT-15930).
+    - name: Pre-clean conflicting ops-repo apt source
+      ansible.builtin.import_tasks: tasks/preclean-ops-repo-trusted-conflict.yml
     - name: Remove Ansible repository
       ansible.builtin.apt_repository:
         repo: "ppa:ansible/ansible"

--- a/ansible/configure-core-local.yml
+++ b/ansible/configure-core-local.yml
@@ -38,6 +38,10 @@
     - config/vars.yml
     - sites/{{ hcv_environment }}/vars.yml
   pre_tasks:
+    # Must run before the apt cache update below: clears a conflicting
+    # trusted=yes/signed-by ops-repo source that would fail apt (JIT-15930).
+    - name: Pre-clean conflicting ops-repo apt source
+      ansible.builtin.import_tasks: tasks/preclean-ops-repo-trusted-conflict.yml
     - name: Remove Ansible repository
       ansible.builtin.apt_repository:
         repo: "ppa:ansible/ansible"

--- a/ansible/configure-haproxy-local.yml
+++ b/ansible/configure-haproxy-local.yml
@@ -104,6 +104,10 @@
     - config/vars.yml
     - sites/{{ hcv_environment }}/vars.yml
   pre_tasks:
+    # Must run before the apt cache update below: clears a conflicting
+    # trusted=yes/signed-by ops-repo source that would fail apt (JIT-15930).
+    - name: Pre-clean conflicting ops-repo apt source
+      ansible.builtin.import_tasks: tasks/preclean-ops-repo-trusted-conflict.yml
     - name: Gather AWS facts
       amazon.aws.ec2_metadata_facts:
       tags: "ec2_facts"

--- a/ansible/configure-jigasi-haproxy-local-oracle.yml
+++ b/ansible/configure-jigasi-haproxy-local-oracle.yml
@@ -19,6 +19,10 @@
     jigasi_haproxy_hostname: "{{ hcv_environment }}-jigasi-haproxy-{{ jigasi_haproxy_component_id }}.infra.jitsi.net"
     shard_role: jigasi-haproxy
   pre_tasks:
+    # Must run before the apt cache update below: clears a conflicting
+    # trusted=yes/signed-by ops-repo source that would fail apt (JIT-15930).
+    - name: Pre-clean conflicting ops-repo apt source
+      ansible.builtin.import_tasks: tasks/preclean-ops-repo-trusted-conflict.yml
     - name: Set cloud provider to oracle
       ansible.builtin.set_fact:
         cloud_provider: oracle

--- a/ansible/configure-jigasi-local-oracle.yml
+++ b/ansible/configure-jigasi-local-oracle.yml
@@ -38,6 +38,10 @@
     - sites/{{ hcv_environment }}/vars.yml
 
   pre_tasks:
+    # Must run before the apt cache update below: clears a conflicting
+    # trusted=yes/signed-by ops-repo source that would fail apt (JIT-15930).
+    - name: Pre-clean conflicting ops-repo apt source
+      ansible.builtin.import_tasks: tasks/preclean-ops-repo-trusted-conflict.yml
     - name: Remove Ansible repository
       ansible.builtin.apt_repository:
         repo: "ppa:ansible/ansible"

--- a/ansible/tasks/preclean-ops-repo-trusted-conflict.yml
+++ b/ansible/tasks/preclean-ops-repo-trusted-conflict.yml
@@ -1,0 +1,31 @@
+---
+# Boot-time safety net for the ops-repo signed-by migration (JIT-15930).
+#
+# Hosts/images that carry BOTH a legacy `deb [trusted=yes] <ops-repo> unstable/`
+# source and the new `deb [signed-by=...] <ops-repo> unstable/` source fail every
+# apt operation with "E: Conflicting values set for option Trusted". That breaks
+# the boot-time apt cache update *before* the jitsi-repo role can reconcile it, so
+# the fix has to run ahead of that apt update.
+#
+# Remove the legacy trusted=yes line ONLY when a signed-by line for the same repo
+# also exists (a genuine conflict) -- not-yet-migrated hosts (trusted=yes only)
+# keep their source until the jitsi-repo role migrates them normally. Uses a plain
+# file edit because apt / apt_repository cannot run while the sources conflict.
+- name: List ops-repo source files that conflict (trusted=yes and signed-by both present)
+  ansible.builtin.shell: >-
+    set -o pipefail;
+    if grep -rqE 'signed-by=.*{{ jitsi_repo_host | regex_escape }}/debian' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null; then
+      grep -rlE 'trusted=yes.*{{ jitsi_repo_host | regex_escape }}/debian' /etc/apt/sources.list /etc/apt/sources.list.d/ 2>/dev/null || true;
+    fi
+  args:
+    executable: /bin/bash
+  register: ops_repo_trusted_conflict_files
+  changed_when: false
+  check_mode: false
+
+- name: Remove legacy [trusted=yes] ops-repo source lines that conflict with signed-by
+  ansible.builtin.lineinfile:
+    path: "{{ item }}"
+    regexp: 'trusted=yes.*{{ jitsi_repo_host | regex_escape }}/debian/?\s+unstable/'
+    state: absent
+  loop: "{{ ops_repo_trusted_conflict_files.stdout_lines | default([]) }}"


### PR DESCRIPTION
## Incident

Shards (and other jitsi nodes) fail at boot:

```
E:Conflicting values set for option Trusted regarding source https://ops-repo.jitsi.net/debian/ unstable/, E:The list of sources could not be read.
```

Hosts/images that carry **both** a legacy `deb [trusted=yes] <ops-repo> unstable/` and the new `deb [signed-by=…] <ops-repo> unstable/` source make every apt operation fail. The boot playbook's early **`Update apt cache` pre-task** (async, retries 3 — this is the failing task) hits it **before** the `jitsi-repo` role's own pre-clean can reconcile it.

## Fix

New shared task file `ansible/tasks/preclean-ops-repo-trusted-conflict.yml`, imported as the **first pre-task** (ahead of `apt-get update`) in the affected boot playbooks. It:
- removes the legacy `[trusted=yes]` ops-repo line via a plain file edit (apt can't run while the sources conflict), and
- **only when a `signed-by` line for the same repo also exists** — so not-yet-migrated hosts (trusted=yes only) keep their source until the `jitsi-repo` role migrates them normally.

### Playbooks updated
`configure-core-local` (shards), `configure-consul-server-local-oracle`, `configure-haproxy-local`, `configure-jigasi-local-oracle`, `configure-jigasi-haproxy-local-oracle` — the boot playbooks that have an early apt-update pre-task **and** consume ops-repo.

Not needed elsewhere: **JVB/jibri** have no early apt-update pre-task, so the `jitsi-repo` role's own pre-clean (from #925) covers them; **ops-repo server / selenium-grid** don't consume the repo.

## Note
CI `ansible-lint --syntax-check` needs the vault password; the new task file lints clean on its own, and the playbook edits are import_tasks insertions placed before each `Update apt cache`.

Ref: JIT-15930