### PR TITLE
fix(configure): drop inline trusted=yes ops-repo setup on jitsi-repo nodes (JIT-15930)

### DIFF
--- a/ansible/configure-core-local.yml
+++ b/ansible/configure-core-local.yml
@@ -67,21 +67,6 @@
         repo: "deb [trusted=yes] {{ jitsi_auth_url_old }} unstable/"
         state: absent
       tags: setup
-    - name: Setup new repo template file
-      ansible.builtin.template:
-        dest: "/etc/apt/auth.conf.d/jitsi-repo.conf"
-        src: "roles/jitsi-repo/templates/jitsi-repo.conf.j2"
-        owner: root
-        mode: 0600
-      tags: setup
-
-    - name: Setup new trusted jitsi repo
-      ansible.builtin.apt_repository:
-        repo: "deb [trusted=yes] {{ jitsi_repo_url }} unstable/"
-        state: present
-        update_cache: false
-      tags: setup
-
     - name: Remove deprecated old repo
       ansible.builtin.apt_repository:
         repo: "deb [trusted=yes] {{ jitsi_repo_url_old }} unstable/"

--- a/ansible/configure-coturn-oracle.yml
+++ b/ansible/configure-coturn-oracle.yml
@@ -59,19 +59,6 @@
         repo: "deb [trusted=yes] {{ jitsi_auth_url_old }} unstable/"
         state: absent
       tags: setup
-    - name: Setup new repo template file
-      ansible.builtin.template:
-        dest: "/etc/apt/auth.conf.d/jitsi-repo.conf"
-        src: "roles/jitsi-repo/templates/jitsi-repo.conf.j2"
-        owner: root
-        mode: 0600
-      tags: setup
-    - name: Setup new trusted jitsi repo
-      ansible.builtin.apt_repository:
-        repo: "deb [trusted=yes] {{ jitsi_repo_url }} unstable/"
-        state: present
-        update_cache: false
-      tags: setup
     - name: Remove deprecated old repo
       ansible.builtin.apt_repository:
         repo: "deb [trusted=yes] {{ jitsi_repo_url_old }} unstable/"

--- a/ansible/configure-jibri-java-local-oracle.yml
+++ b/ansible/configure-jibri-java-local-oracle.yml
@@ -74,14 +74,6 @@
         jibri_version: "{{ jibri_version_cmd.stdout }}"
       changed_when: jibri_version_cmd.rc != 0
       when: not jibri_docker_compose_flag
-    - name: Setup new repo template file
-      ansible.builtin.template:
-        dest: "/etc/apt/auth.conf.d/jitsi-repo.conf"
-        src: "roles/jitsi-repo/templates/jitsi-repo.conf.j2"
-        owner: root
-        mode: 0600
-      tags: setup
-
   post_tasks:
     - name: Restart rsyslog
       ansible.builtin.service:

--- a/ansible/configure-jigasi-local-oracle.yml
+++ b/ansible/configure-jigasi-local-oracle.yml
@@ -79,19 +79,6 @@
         state: absent
         update_cache: false
       tags: setup
-    - name: Setup new repo template file
-      ansible.builtin.template:
-        dest: "/etc/apt/auth.conf.d/jitsi-repo.conf"
-        src: "roles/jitsi-repo/templates/jitsi-repo.conf.j2"
-        owner: root
-        mode: 0600
-      tags: setup
-    - name: Setup new trusted jitsi repo
-      ansible.builtin.apt_repository:
-        repo: "deb [trusted=yes] {{ jitsi_repo_url }} unstable/"
-        state: present
-        update_cache: false
-      tags: setup
     - name: Remove deprecated old repo
       ansible.builtin.apt_repository:
         repo: "deb [trusted=yes] {{ jitsi_repo_url_old }} unstable/"

--- a/ansible/configure-jvb-local-oracle.yml
+++ b/ansible/configure-jvb-local-oracle.yml
@@ -82,19 +82,6 @@
         state: absent
         update_cache: false
       tags: setup
-    - name: Setup new repo template file
-      ansible.builtin.template:
-        dest: "/etc/apt/auth.conf.d/jitsi-repo.conf"
-        src: "roles/jitsi-repo/templates/jitsi-repo.conf.j2"
-        owner: root
-        mode: 0600
-      tags: setup
-    - name: Setup new trusted jitsi repo
-      ansible.builtin.apt_repository:
-        repo: "deb [trusted=yes] {{ jitsi_repo_url }} unstable/"
-        state: present
-        update_cache: false
-      tags: setup
     - name: Remove deprecated old repo
       ansible.builtin.apt_repository:
         repo: "deb [trusted=yes] {{ jitsi_repo_url_old }} unstable/"


### PR DESCRIPTION
## Root cause of the boot conflict

The configure playbooks set up the ops-repo apt source **inline** in `pre_tasks`:

```
- name: Setup new trusted jitsi repo
  ansible.builtin.apt_repository:
    repo: "deb [trusted=yes] {{ jitsi_repo_url }} unstable/"
    state: present
```

…**in addition** to the `jitsi-repo` role (pulled in via `jicofo`/`jitsi-meet`/`jigasi`/`jibri-java`/`coturn`/`jitsi-videobridge` meta-deps), which now configures the same URI as `signed-by`. Two entries, conflicting `Trusted` → `E: Conflicting values set for option Trusted` at the boot apt update. Every run re-adds `trusted=yes` on top of `signed-by`.

This is the actual source of the incident; #930's boot pre-clean only masked it (and couldn't, because the inline task re-adds `trusted=yes` *after* the pre-clean and *before* the apt update).

## Fix

Remove the inline `Setup new repo template file` + `Setup new trusted jitsi repo` tasks from the playbooks that **run the jitsi-repo role** — the role provides both the auth file and the verified `signed-by` source:
- `configure-core-local` (shards), `configure-jvb-local-oracle`, `configure-jigasi-local-oracle`, `configure-jibri-java-local-oracle`, `configure-coturn-oracle`

Left as-is:
- The `state: absent` legacy cleanups (harmless).
- `configure-haproxy-local`, `configure-consul-server-local-oracle`, `configure-jigasi-haproxy-local-oracle` — these do **not** run the jitsi-repo role, so their inline `[trusted=yes]` is their only ops-repo source (no `signed-by`, no conflict). Migrating those to `signed-by` is a separate follow-up.

## Validation
ansible-lint shows only the pre-existing `internal-error` (local vault password needed for `--syntax-check`), no structural `yaml[...]` errors; task blocks removed cleanly (verified surrounding structure).

Ref: JIT-15930