### PR TITLE
feat: Provision live audio translation

### DIFF
--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -72,6 +72,7 @@ jicofo_source_signaling_delay: { 50: 1000, 100: 2000 }
 jicofo_ssrc_rewriting: true
 jicofo_stress_threshold: 0.8
 jicofo_transcription_url_template: false
+jicofo_translation_url_template: false
 jicofo_use_presence_for_jvb_health: false
 jicofo_visitors_enabled: "{{ visitors_enabled | default(false) }}"
 jicofo_visitors_enable_live_room: false

--- a/ansible/roles/jicofo/templates/jicofo.conf.j2
+++ b/ansible/roles/jicofo/templates/jicofo.conf.j2
@@ -160,6 +160,18 @@ jicofo {
     }
     {% endif %}
   }
+  translation {
+    {% if jicofo_translation_url_template %}
+    url-template = "{{ jicofo_translation_url_template }}"
+    {% endif %}
+
+    {% if secrets_jicofo_opus_transcriber_client_id %}
+    http-headers {
+        "CF-Access-Client-Id": {{ secrets_jicofo_opus_transcriber_client_id }}
+        "CF-Access-Client-Secret": {{ secrets_jicofo_opus_transcriber_secret }}
+    }
+    {% endif %}
+  }
 
 
   {% if jicofo_visitors_enabled %}

--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -146,6 +146,7 @@ prosody_log_syslog_hostname: localhost
 prosody_log_syslog_port: 514
 prosody_log_syslog_proto: udp
 prosody_max_number_outgoing_calls: 3
+prosody_meet_audio_translation_enabled: false
 prosody_meet_auth_vpaas_enabled: false
 prosody_meet_av_moderation_enabled: true
 prosody_meet_chat_history_url: false

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -843,6 +843,11 @@ Component "metadata.{{ prosody_domain_name }}" "room_metadata_component"
     breakout_rooms_component = "breakout.{{ prosody_domain_name }}"
 {% endif %}
 
+{% if prosody_meet_audio_translation_enabled %}
+Component "audiotranslation.{{ prosody_domain_name }}" "audio_translation_component"
+    muc_component = "conference.{{ prosody_domain_name }}"
+{% endif %}
+
 {% if prosody_visitors_enabled %}
 Component "visitors.{{ prosody_domain_name }}" "visitors_component"
     {% if prosody_visitors_auto_allow %}


### PR DESCRIPTION
Adds the ansible provisioning for the live audio translation feature (jicofo + prosody), following the transcription scheme.

- **jicofo** (`jicofo.conf.j2`): a `translation {}` block driven by `jicofo_translation_url_template` (default false), reusing the same `secrets_jicofo_opus_transcriber_*` CF-Access http-headers as transcription.
- **prosody** (`prosody.cfg.lua.j2`): an `audiotranslation.<domain>` component (`audio_translation_component`) gated by `prosody_meet_audio_translation_enabled` (default false), placed after `room_metadata` (which it depends on).

Per-site enablement (stage-8x8) is in infra-customizations-private (cross-linked PR). The nomad/docker (cloud) path is deferred — docker-jitsi-meet has no audio_translation component or jicofo translation env yet.