### PR TITLE
feat(jitsi-meet): add jitsi_meet_enable_audio_translation flag

### DIFF
--- a/ansible/roles/jitsi-meet/defaults/main.yml
+++ b/ansible/roles/jitsi-meet/defaults/main.yml
@@ -137,6 +137,7 @@ jitsi_meet_dropbox_app_key: false
 jitsi_meet_dump_transcript: false
 jitsi_meet_e2eping_enabled: false
 jitsi_meet_enable_advanced_audio_settings: false
+jitsi_meet_enable_audio_translation: false
 jitsi_meet_enable_calendar: false
 jitsi_meet_enable_colibri_websockets: false
 jitsi_meet_enable_conference_request_http: false

--- a/ansible/roles/jitsi-meet/templates/config.js.j2
+++ b/ansible/roles/jitsi-meet/templates/config.js.j2
@@ -186,6 +186,11 @@ var config = {
         enableOpusDtx: {% if jitsi_meet_enable_dtx %}true{% else %}false{% endif %},
         enableAdvancedAudioSettings: {% if jitsi_meet_enable_advanced_audio_settings %}true{% else %}false{% endif %}
     },
+{% if jitsi_meet_enable_audio_translation %}
+    audioTranslation: {
+        enabled: true
+    },
+{% endif %}
 {% if jitsi_meet_talk_while_muted_enabled %}
     enableTalkWhileMuted: true,
 {% endif %}


### PR DESCRIPTION
## Summary

Adds a `jitsi_meet_enable_audio_translation` ansible var (default `false`) and emits `audioTranslation: { enabled: true }` into the rendered `config.js` when it is set. No behavior change for existing sites — the block is only emitted when a site overrides the var.

## Companion changes

- infra-provisioning: https://github.com/jitsi/infra-provisioning/pull/1119
- infra-customizations-private: https://github.com/jitsi/infra-customizations-private/pull/1060

## Test plan

- `defaults/main.yml`: var defaults to `false`; rendered `config.js` for sites without an override omits `audioTranslation`.
- `config.js.j2`: with `jitsi_meet_enable_audio_translation: true`, rendered `config.js` contains `audioTranslation: { enabled: true }` and remains valid JS.
