### PR TITLE
feat(prosody): use in-memory storage for mod_smacks smacks_h store (JIT-16012)

### DIFF
--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -296,8 +296,11 @@ authentication = "internal_hashed"
 -- through modules. An "sql" backend is included by default, but requires
 -- additional dependencies. See http://prosody.im/doc/storage for more info.
 
-storage = "internal" -- Default is "internal" (Debian: "sql" requires one of the
+default_storage = "internal" -- Default is "internal" (Debian: "sql" requires one of the
 -- lua-dbi-sqlite3, lua-dbi-mysql or lua-dbi-postgresql packages to work)
+storage = {
+    smacks_h = "memory";
+}
 
 -- For the "sql" backend, you can uncomment *one* of the below to configure:
 -- sql = { driver = "MySQL", database = "prosody", username = "<< prosody_db_user >>", password = "<< prosody_db_password >>", host = "<< prosody_db_host >>" }


### PR DESCRIPTION
## Summary
Configure Prosody to keep the mod_smacks hibernation queue store (`smacks_h`) in memory rather than the disk-based `internal` storage backend.

## Change
In `ansible/roles/prosody/templates/prosody.cfg.lua.j2` the global `storage` declaration is converted from a plain string to a map so that only the `smacks_h` store is redirected to the `memory` backend. All other stores continue to fall back to `default_storage = "internal"`.

```lua
default_storage = "internal"
storage = {
    smacks_h = "memory";
}
```

Applied unconditionally — harmless when `mod_smacks` is not loaded.

## Rationale
mod_smacks uses the `smacks_h` store for hibernated (resumable) session queues. Keeping this transient state in memory avoids unnecessary disk I/O.

Ref: JIT-16012