### PR TITLE
feat(vault): seal watchdog + consul service registration

### DIFF
--- a/ansible/roles/consul-vault/defaults/main.yml
+++ b/ansible/roles/consul-vault/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+consul_vault_private_ip: "{{ ansible_default_ipv4.address }}"

--- a/ansible/roles/consul-vault/handlers/main.yml
+++ b/ansible/roles/consul-vault/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart consul for consul-vault
+  ansible.builtin.service:
+    name: consul
+    state: reloaded

--- a/ansible/roles/consul-vault/meta/main.yml
+++ b/ansible/roles/consul-vault/meta/main.yml
@@ -1,0 +1,13 @@
+---
+galaxy_info:
+  role_name: consul_vault
+  author: Aaron van Meerten
+  description: register vault server nodes as a consul service for discovery
+  license: Apache License Version 2.0
+  min_ansible_version: '6.6.0'
+  platforms:
+    - name: Ubuntu
+      releases:
+        - jammy
+        - noble
+dependencies: []

--- a/ansible/roles/consul-vault/tasks/main.yml
+++ b/ansible/roles/consul-vault/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Install consul service file
+  ansible.builtin.template:
+    mode: 0644
+    src: "vault.json.j2"
+    dest: "/etc/consul.d/vault.json"
+  notify: Restart consul for consul-vault
+
+- name: Install consul service enablement # noqa ignore-errors
+  ansible.builtin.systemd:
+    name: consul
+    state: reloaded
+    enabled: true
+  ignore_errors: true

--- a/ansible/roles/consul-vault/templates/vault.json.j2
+++ b/ansible/roles/consul-vault/templates/vault.json.j2
@@ -1,0 +1,31 @@
+{
+  "service": {
+    "name": "vault",
+    "tags": ["{{ hcv_environment }}", "vault-server"],
+    "meta": {
+      "environment": "{{ hcv_environment }}"
+    },
+    "tagged_addresses": {
+      "lan": {
+        "address": "{{ consul_vault_private_ip }}",
+        "port": 8200
+      },
+      "wan": {
+        "address": "{{ consul_vault_private_ip }}",
+        "port": 8200
+      }
+    },
+    "port": 8200,
+    "checks": [
+      {
+        "id": "vault-health",
+        "name": "Vault health (unsealed)",
+        "http": "https://127.0.0.1:8200/v1/sys/health?standbyok=true&perfstandbyok=true",
+        "method": "GET",
+        "tls_skip_verify": true,
+        "interval": "10s",
+        "timeout": "3s"
+      }
+    ]
+  }
+}

--- a/ansible/roles/consul-vault/templates/vault.json.j2
+++ b/ansible/roles/consul-vault/templates/vault.json.j2
@@ -1,6 +1,7 @@
 {
   "service": {
     "name": "vault",
+    "address": "{{ consul_vault_private_ip }}",
     "tags": ["{{ hcv_environment }}", "vault-server"],
     "meta": {
       "environment": "{{ hcv_environment }}"

--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -13,6 +13,9 @@ vault_lock_bucket_name: "vault-lock"
 vault_log_dir: /var/log
 vault_management_endpoint:
 vault_role: "agent"
+# install a systemd timer that restarts vault if it gets stuck sealed
+# (auto-unseal makes a restart self-recovering); server nodes only
+vault_seal_watchdog_enabled: true
 vault_tls_cert_path: /opt/vault/tls/tls.crt
 vault_tls_key_path: /opt/vault/tls/tls.key
 vault_agent_replace_pattern: _REPLACE_PATTERN_

--- a/ansible/roles/vault/files/vault-seal-watchdog.service
+++ b/ansible/roles/vault/files/vault-seal-watchdog.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Vault seal watchdog - restart vault if it is stuck sealed
+Documentation=https://developer.hashicorp.com/vault/docs/concepts/seal
+After=vault.service
+ConditionFileNotEmpty=/etc/vault.d/vault.hcl
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/vault-seal-watchdog.sh

--- a/ansible/roles/vault/files/vault-seal-watchdog.sh
+++ b/ansible/roles/vault/files/vault-seal-watchdog.sh
@@ -36,7 +36,7 @@ mkdir -p "$STATE_DIR"
 #   472 DR secondary active           473 performance standby
 #   501 not initialized               503 sealed
 # We only act on 503 (sealed) or a connection failure (000).
-code="$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "$HEALTH_URL" || echo 000)"
+code="$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "$HEALTH_URL")" || code=000
 
 case "$code" in
   200|429|472|473|501)

--- a/ansible/roles/vault/files/vault-seal-watchdog.sh
+++ b/ansible/roles/vault/files/vault-seal-watchdog.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+#
+# vault-seal-watchdog.sh
+#
+# Restarts vault.service if the node has been sealed (or unreachable) for
+# several consecutive checks. Vault seals itself when it hits an unrecoverable
+# storage error during post-unseal (e.g. a transient OCI Object Storage 5xx
+# while restoring leases/entities) and then keeps running *sealed* -- it does
+# not exit, so systemd's Restart=on-failure never fires and the node stays dark
+# until an operator restarts it by hand.
+#
+# Because these nodes use auto-unseal (ocikms), a plain `systemctl restart`
+# re-unseals the node automatically. This watchdog turns a stuck seal into a
+# ~1-2 minute blip instead of a manual-recovery outage (see JIT vault runbook).
+#
+# Driven by vault-seal-watchdog.timer (runs every 60s). Safe to run on standby
+# nodes: a healthy standby returns 429 and is treated as healthy.
+set -euo pipefail
+
+HEALTH_URL="${VAULT_WATCHDOG_HEALTH_URL:-https://127.0.0.1:8200/v1/sys/health}"
+STATE_DIR="/run/vault-seal-watchdog"
+FAIL_FILE="$STATE_DIR/consecutive_bad"
+LAST_RESTART_FILE="$STATE_DIR/last_restart"
+
+# How many consecutive bad checks before we act (guards against normal startup /
+# leadership-transition blips). With a 60s timer this is ~2 minutes of sealed.
+FAIL_THRESHOLD="${VAULT_WATCHDOG_FAIL_THRESHOLD:-2}"
+# Never restart more often than this many seconds (guards against a tight
+# restart<->seal loop when storage is genuinely down for an extended period).
+MIN_RESTART_INTERVAL="${VAULT_WATCHDOG_MIN_RESTART_INTERVAL:-180}"
+
+mkdir -p "$STATE_DIR"
+
+# /v1/sys/health status codes:
+#   200 initialized+unsealed+active   429 unsealed+standby
+#   472 DR secondary active           473 performance standby
+#   501 not initialized               503 sealed
+# We only act on 503 (sealed) or a connection failure (000).
+code="$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "$HEALTH_URL" || echo 000)"
+
+case "$code" in
+  200|429|472|473|501)
+    # healthy (or deliberately uninitialized) -- reset the failure counter
+    rm -f "$FAIL_FILE"
+    exit 0
+    ;;
+esac
+
+fails=$(( $(cat "$FAIL_FILE" 2>/dev/null || echo 0) + 1 ))
+echo "$fails" > "$FAIL_FILE"
+logger -t vault-seal-watchdog "vault health returned ${code} (sealed/unreachable); consecutive=${fails}/${FAIL_THRESHOLD}"
+
+if [ "$fails" -lt "$FAIL_THRESHOLD" ]; then
+  exit 0
+fi
+
+now="$(date +%s)"
+last="$(cat "$LAST_RESTART_FILE" 2>/dev/null || echo 0)"
+if [ "$(( now - last ))" -lt "$MIN_RESTART_INTERVAL" ]; then
+  logger -t vault-seal-watchdog "vault still bad but last restart was $(( now - last ))s ago (< ${MIN_RESTART_INTERVAL}s); skipping"
+  exit 0
+fi
+
+logger -t vault-seal-watchdog "vault sealed/unreachable for ${fails} checks (code=${code}); restarting vault.service"
+echo "$now" > "$LAST_RESTART_FILE"
+rm -f "$FAIL_FILE"
+systemctl restart vault.service

--- a/ansible/roles/vault/files/vault-seal-watchdog.timer
+++ b/ansible/roles/vault/files/vault-seal-watchdog.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run the vault seal watchdog periodically
+Documentation=https://developer.hashicorp.com/vault/docs/concepts/seal
+
+[Timer]
+# wait past normal boot/unseal before the first check, then check every minute
+OnBootSec=120
+OnUnitActiveSec=60
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/vault/tasks/configure.yml
+++ b/ansible/roles/vault/tasks/configure.yml
@@ -22,6 +22,31 @@
     enabled: true
   when: vault_role == "server"
 
+- name: Install vault seal watchdog script
+  ansible.builtin.copy:
+    mode: 0755
+    src: vault-seal-watchdog.sh
+    dest: /usr/local/bin/vault-seal-watchdog.sh
+  when: vault_role == "server" and vault_seal_watchdog_enabled
+
+- name: Install vault seal watchdog systemd units
+  ansible.builtin.copy:
+    mode: 0644
+    src: "{{ item }}"
+    dest: "/usr/lib/systemd/system/{{ item }}"
+  loop:
+    - vault-seal-watchdog.service
+    - vault-seal-watchdog.timer
+  when: vault_role == "server" and vault_seal_watchdog_enabled
+
+- name: Enable vault seal watchdog timer
+  ansible.builtin.systemd:
+    name: vault-seal-watchdog.timer
+    enabled: true
+    state: started
+    daemon_reload: true
+  when: vault_role == "server" and vault_seal_watchdog_enabled
+
 - name: Install vault-proxy pre start script
   ansible.builtin.template:
     mode: 0755


### PR DESCRIPTION
## Why

Follow-up to the 2026-07-09 ops-prod Vault outage (root cause: a transient OCI Object Storage 5xx/412 burst made the active node fail post-unseal and **seal itself**; recovery was manual because a sealed Vault keeps running and `Restart=on-failure` never fires).

## What

**Seal watchdog** (`roles/vault`)
- `vault-seal-watchdog.sh` + `.service` + `.timer`: every 60s, restart `vault.service` if `/v1/sys/health` reports sealed (503) or unreachable for ~2 consecutive checks, rate-limited to one restart / 180s.
- Auto-unseal (`ocikms`) means a restart re-unseals automatically — turns a stuck seal into a ~1-2 min blip instead of a manual-recovery outage.
- Gated by `vault_seal_watchdog_enabled` (default true); server nodes only.

**`consul-vault` role**
- Drops `/etc/consul.d/vault.json` registering each node as consul service `vault` (port 8200) with an HTTP health check (`/v1/sys/health?standbyok=true&perfstandbyok=true`, `tls_skip_verify`), then reloads consul.
- Lets cloudprober discover vault nodes for per-node seal probing (see infra-provisioning PR) with no hardcoded IPs and no redeploy on rotation.
- Follows the existing `consul-telegraf` / `consul-signal` role pattern; wired into `configure-vault-local.yml` in the infra-customizations-private PR.

## Testing (validated on ops-dev vault `10.35.176.202`, 2026-07-21)

**Phase 1 — watchdog script:**
- Healthy vault → exits 0, no action, PID unchanged.
- Failure counting (unreachable URL, high threshold) → counter increments 1→2, never restarts.
- Real restart (threshold 2) → fired `systemctl restart vault`; vault **auto-unsealed and returned to `active` in ~5s**. End-to-end recovery confirmed.

**Phase 2 — ansible roles** (on-box, `-c local --tags vault,consul-vault`; OCI/env vars supplied so `vault.hcl` renders identically = no vault restart, verified `ok` in a `--check --diff` dry run first):
- Real run `failed=0`; watchdog script/units installed, timer enabled+active, `vault.json` registered, consul reloaded.
- Idempotent on re-run (only the consul `reload` action reports changed, consistent with the existing `consul-*` roles).
- Consul service verified registered as `10.35.176.202:8200`, both health checks passing.

**Two fixes made during testing (included in this PR):**
1. `vault-seal-watchdog.sh`: curl-failure status logged as `000000` instead of `000` (the `-w` output and the `|| echo 000` fallback both printed). Now `code=000` on curl non-zero exit.
2. `consul-vault/templates/vault.json.j2`: service registered with an **empty `Address`**, which would make the cloudprober probe render `https://:8200/...`. Added an explicit top-level `"address"` = node private IP.

Watchdog + consul service left installed on ops-dev.

## Notes
- Sealed-but-running nodes still listen on 8200 (return 503), so the health check observes the seal and the watchdog acts.
- If storage is genuinely down the watchdog will restart→reseal until storage recovers; intentional, self-healing, and rate-limited.