### PR TITLE
feat(prosody): set breakout_rooms_component on the audio-translation component

### DIFF
--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -849,6 +849,7 @@ Component "metadata.{{ prosody_domain_name }}" "room_metadata_component"
 {% if prosody_meet_audio_translation_enabled %}
 Component "audiotranslation.{{ prosody_domain_name }}" "audio_translation_component"
     muc_component = "conference.{{ prosody_domain_name }}"
+    breakout_rooms_component = "breakout.{{ prosody_domain_name }}"
 {% endif %}
 
 {% if prosody_visitors_enabled %}


### PR DESCRIPTION
## What
Set `breakout_rooms_component = "breakout.<domain>"` on the prosody `audio_translation_component`, mirroring the `room_metadata_component` that already has it.

## Why
`mod_audio_translation_component` gained a breakout occupant-leave prune hook that only activates when this option is set, so a translation subscription issued inside a breakout room is cleaned up when the subscriber leaves the breakout. Without it, breakout subscriptions and the inverted listeners map can leak stale entries.

Core breakout translation works without this (the message handler resolves the breakout room via `get_occupant_by_real_jid` regardless) — this closes the cleanup gap.

## Notes
- Pairs with jitsi/jitsi-meet#17643 (the `mod_audio_translation_component` breakout change) and 8x8Cloud/jitsi-meet-branding#390 (entitlement/token propagation).
- Unconditional like the metadata component's setting; harmless when breakout rooms are disabled (the component simply never loads).
