### PR TITLE
feat(ansible): replace carbon-black role with falcon-sensor

### DIFF
--- a/ansible/configure-consul-server-local-oracle.yml
+++ b/ansible/configure-consul-server-local-oracle.yml
@@ -10,7 +10,7 @@
     - secrets/consul.yml
     - secrets/repo.yml
     - secrets/nomad.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - config/vars.yml
     - sites/{{ hcv_environment }}/vars.yml
   vars:
@@ -180,7 +180,7 @@
     #       environment: "{{ hcv_environment }}"
     #       region: "{{ cloud_region }}"
     #       cloud_provider: "{{ cloud_provider }}"
-    - { role: "carbon-black", tags: "carbon-black", when: carbon_black_install_flag}
+    - { role: "falcon-sensor", tags: "falcon-sensor", when: falcon_sensor_install_flag}
   tasks:
     - name: Start nomad
       ansible.builtin.service:

--- a/ansible/configure-firezone.yml
+++ b/ansible/configure-firezone.yml
@@ -8,7 +8,7 @@
   vars_files:
     - secrets/ssh-users.yml
     - secrets/ssl-certificates.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - config/vars.yml
     - sites/{{ hcv_environment }}/vars.yml
   vars:
@@ -34,4 +34,4 @@
     - { role: "docker", tags: "docker"}
     - { role: "iptables-firezone", tags: "iptables"}
     - { role: "firezone", tags: "firezone"}
-    - { role: "carbon-black", tags: "carbon-black", when: carbon_black_install_flag}
+    - { role: "falcon-sensor", tags: "falcon-sensor", when: falcon_sensor_install_flag}

--- a/ansible/configure-jigasi-haproxy-local-oracle.yml
+++ b/ansible/configure-jigasi-haproxy-local-oracle.yml
@@ -11,7 +11,7 @@
     - secrets/consul.yml
     - config/vars.yml
     - secrets/repo.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - sites/{{hcv_environment}}/vars.yml
   vars:
     cloud_provider: oracle
@@ -85,4 +85,4 @@
           region: "{{ oracle_to_aws_region_map[region] }}"
           oracle_region: "{{ region }}"
           cloud: "oracle"
-    - { role: "carbon-black", tags: "carbon-black", when: carbon_black_install_flag}
+    - { role: "falcon-sensor", tags: "falcon-sensor", when: falcon_sensor_install_flag}

--- a/ansible/configure-jumpbox.yml
+++ b/ansible/configure-jumpbox.yml
@@ -7,7 +7,7 @@
   strategy: free
   vars_files:
     - secrets/ssh-users.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - config/vars.yml
     - "sites/{{ hcv_environment }}/vars.yml"
   vars:
@@ -24,11 +24,11 @@
       tags: setup
   roles:
     - { role: "sshusers", tags: "ssh" }
-    - { role: "sshmfa", tags: "sshmfa", when: carbon_black_install_flag}
+    - { role: "sshmfa", tags: "sshmfa", when: falcon_sensor_install_flag}
     - { role: "fail2ban", tags: "fail2ban" }
     - { role: "unattended-upgrades", tags: "unattended-upgrades"}
     - { role: "ntp", tags: "ntp"}
     - { role: "logrotate", tags: "logrotate"}
     - { role: "journald", tags: "journald"}
     - { role: "rsyslog", rsyslog_install_flag: false, tags: "rsyslog"}
-    - { role: "carbon-black", tags: "carbon-black", when: carbon_black_install_flag}
+    - { role: "falcon-sensor", tags: "falcon-sensor", when: falcon_sensor_install_flag}

--- a/ansible/configure-standalone-compose.yml
+++ b/ansible/configure-standalone-compose.yml
@@ -50,7 +50,7 @@
   # initial system pre-requisites
 #    - { role: "vault", tags: "vault", vault_install_flag: true, vault_configure_flag: true, vault_agent_startup: true }
     # - { role: "bootstrap-repos", tags: "bootstrap-repos" }
-    # - { role: "carbon-black", tags: "carbon-black" }
+    # - { role: "falcon-sensor", tags: "falcon-sensor" }
     # - { role: "jenkins-sshkey", tags: "jenkins-sshkey"}
     # - { role: "sshusers", tags: "ssh" }
     # - { role: "unattended-upgrades", tags: "unattended-upgrades"}

--- a/ansible/configure-standalone.yml
+++ b/ansible/configure-standalone.yml
@@ -52,7 +52,7 @@
     - secrets/prosody.yml
     - secrets/prosody-egress-aws.yml
     - secrets/repo.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - secrets/github-deploy.yml
     - config/vars.yml
     - sites/{{ hcv_environment }}/vars.yml
@@ -267,7 +267,7 @@
   # initial system pre-requisites
     - { role: "vault", tags: "vault", vault_install_flag: true, vault_configure_flag: true, vault_agent_startup: true }
     # - { role: "bootstrap-repos", tags: "bootstrap-repos" }
-    # - { role: "carbon-black", tags: "carbon-black" }
+    # - { role: "falcon-sensor", tags: "falcon-sensor" }
     - { role: "openjdk-java", tags: "openjdk" }
     - { role: "jenkins-sshkey", tags: "jenkins-sshkey"}
     - { role: "sshusers", tags: "ssh" }

--- a/ansible/configure-wavefront-proxy.yml
+++ b/ansible/configure-wavefront-proxy.yml
@@ -6,7 +6,7 @@
   become: yes
   vars_files:
     - secrets/wavefront.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - config/vars.yml
     - sites/{{ hcv_environment }}/vars.yml
   vars:
@@ -26,4 +26,4 @@
         cloud: "{{ cloud_provider }}"
         environment: "{{ hcv_environment }}"
     - { role: "unattended-upgrades", tags: "unattended-upgrades"}
-    - { role: "carbon-black", tags: "carbon-black", when: carbon_black_install_flag}
+    - { role: "falcon-sensor", tags: "falcon-sensor", when: falcon_sensor_install_flag}

--- a/ansible/nomad-client.yml
+++ b/ansible/nomad-client.yml
@@ -10,7 +10,7 @@
     - secrets/consul.yml
     - secrets/nomad.yml
     - secrets/skynet.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - secrets/asap-keys.yml
     - secrets/ops-repo.yml
     - secrets/repo.yml
@@ -155,7 +155,7 @@
     - { role: "gpu-models", tags: "gpu-models", when: nvidia_docker_flag or skynet_models_flag }
     - { role: "gpu-docker-pull", tags: "gpu-docker", when: nvidia_docker_flag or skynet_models_flag }
     - { role: "nomad", tags: "nomad", nomad_install_flag: false }
-#    - { role: "carbon-black", tags: "carbon-black", when: carbon_black_install_flag}
+#    - { role: "falcon-sensor", tags: "falcon-sensor", when: falcon_sensor_install_flag}
   tasks:
     - name: Flush handlers for docker before nomad starts
       ansible.builtin.meta: flush_handlers

--- a/ansible/nomad-server.yml
+++ b/ansible/nomad-server.yml
@@ -10,7 +10,7 @@
     - secrets/consul.yml
     - secrets/nomad.yml
     - secrets/repo.yml
-    - secrets/carbon-black.yml
+    - secrets/crowdstrike.yml
     - config/vars.yml
     - sites/{{ hcv_environment }}/vars.yml
   vars:
@@ -55,7 +55,7 @@
           region: "{{ cloud_region }}"
           cloud: "{{ cloud_provider }}"
           cloud_provider: "{{ cloud_provider }}"
-    - { role: "carbon-black", tags: "carbon-black", when: carbon_black_install_flag}
+    - { role: "falcon-sensor", tags: "falcon-sensor", when: falcon_sensor_install_flag}
   tasks:
     - name: Consul service enablement
       ansible.builtin.systemd:


### PR DESCRIPTION
## Summary
Replaces CarbonBlack agent installation with the CrowdStrike Falcon sensor.

- Playbooks now use the `falcon-sensor` role (provided by the customizations overlay) instead of `carbon-black`.
- Secrets include switched from `secrets/carbon-black.yml` to `secrets/crowdstrike.yml`.
- `carbon_black_install_flag` renamed to `falcon_sensor_install_flag` (including the `sshmfa` gate in configure-jumpbox.yml, which shares the flag).