### PR TITLE
fix(vault-watchdog): only restart on sealed (503) or unreachable (000)

### DIFF
--- a/ansible/roles/vault/files/vault-seal-watchdog.sh
+++ b/ansible/roles/vault/files/vault-seal-watchdog.sh
@@ -32,15 +32,23 @@ MIN_RESTART_INTERVAL="${VAULT_WATCHDOG_MIN_RESTART_INTERVAL:-180}"
 mkdir -p "$STATE_DIR"
 
 # /v1/sys/health status codes:
-#   200 initialized+unsealed+active   429 unsealed+standby
-#   472 DR secondary active           473 performance standby
-#   501 not initialized               503 sealed
-# We only act on 503 (sealed) or a connection failure (000).
+#   200 active            429 standby            472 DR secondary active
+#   473 performance standby   474 standby w/ unhealthy HA connection
+#   501 not initialized   503 sealed
+# Only 503 (sealed) or 000 (curl failure / vault not listening at all) warrant a
+# restart -- auto-unseal makes a restart self-recovering for a sealed node, and a
+# hung/not-listening node may recover on restart. Every other code is left alone:
+# a restart fixes none of them and would loop. In particular 474 (a standby whose
+# HA connection to the active node is unhealthy) must NOT trigger a restart --
+# restarting only tears down and re-establishes the forwarding connection.
 code="$(curl -sk -o /dev/null -w '%{http_code}' --max-time 5 "$HEALTH_URL")" || code=000
 
 case "$code" in
-  200|429|472|473|501)
-    # healthy (or deliberately uninitialized) -- reset the failure counter
+  503|000)
+    # actionable -- fall through to the failure-counting / restart logic below
+    ;;
+  *)
+    # active / standby / HA-degraded / uninitialized / anything else -- no action
     rm -f "$FAIL_FILE"
     exit 0
     ;;


### PR DESCRIPTION
## Problem (found in ops-prod post-release validation)

The seal-watchdog crash-looped vault on a healthy **standby** node (10.34.136.43), restarting it every ~180s.

Root cause: the health check whitelisted healthy codes (`200|429|472|473|501`) and treated **everything else** as a restart trigger. A Vault standby whose HA connection to the active node is unhealthy returns **474** (`haunhealthycode`), which fell through to the restart path. A restart can't fix an HA-connection issue (and each restart tears the forwarding connection back down), so it looped.

Not caught on ops-dev: that vault is single-node (always active → 200), so the standby/474 path was never exercised.

## Fix

Invert the logic — only two states warrant a restart:
- `503` sealed (auto-unseal makes a restart self-recovering)
- `000` curl failure / vault not listening at all

Every other code — `200/429/472/473/474/501` and anything else — is a no-op (reset counter, exit). Verified by simulation: only 503/000 are actionable; 474 is left alone.

## Related
- Companion infra-provisioning PR updates the `vault_nodes` cloudprober validator to accept 474 (unsealed-but-HA-degraded standby is "up", not a probe failure).
- Follow-up: the underlying dead forwarding link on 10.34.136.43 is a separate, real HA concern to investigate.