### PR TITLE
fix(vault): set cluster_addr for HA request forwarding (JIT-16171)

### DIFF
--- a/ansible/roles/vault/defaults/main.yml
+++ b/ansible/roles/vault/defaults/main.yml
@@ -1,5 +1,11 @@
 ---
 vault_server_api_url: "https://vault.{{ dns_zone_name }}"
+# Address advertised to peers for HA request forwarding. Must be each node's own
+# reachable cluster-listener endpoint (:8201), NOT the load-balancer VIP. When
+# unset, Vault derives it from api_addr with port+1 (e.g. the LB :444), which is
+# not a real cluster endpoint -> ha_connection_healthy=false / HTTP 474 on standbys.
+# Cluster traffic uses Vault's internal cluster TLS, so an IP here is fine.
+vault_server_cluster_addr: "https://{{ ansible_default_ipv4.address }}:8201"
 vault_apt_key: https://apt.releases.hashicorp.com/gpg
 vault_apt_repo: https://apt.releases.hashicorp.com
 vault_architecture: "{{'arm64' if ansible_architecture == 'aarch64' else 'amd64'}}"

--- a/ansible/roles/vault/templates/server.hcl.j2
+++ b/ansible/roles/vault/templates/server.hcl.j2
@@ -1,4 +1,5 @@
 api_addr = "{{ vault_server_api_url }}"
+cluster_addr = "{{ vault_server_cluster_addr }}"
 cluster_name = "vault"
 default_lease_ttl = "5m"
 listener "tcp" {


### PR DESCRIPTION
## Problem (JIT-16171)

Vault HA request forwarding has never worked in ops-prod. `cluster_addr` is unset in `server.hcl.j2`, so Vault derives it from `api_addr` (:443) with **port+1** → `https://ops-prod-us-phoenix-1-vault.jitsi.net:444` (the LB VIP). The OCI LB only has a `443→8200` listener, so `:444` is closed; the real node-to-node cluster port `:8201` is open but never advertised. A standby therefore can't reach the active's cluster endpoint → `ha_connection_healthy=false` and the standby returns HTTP **474** on `/v1/sys/health`.

Latent (LB routes clients only to the active; failover uses the storage lock), but it produced the 474 that crash-looped the seal-watchdog (fixed in infra-configuration#940 / infra-provisioning#1133) and means there's no working request-forwarding path.

## Fix

Add `cluster_addr = "{{ vault_server_cluster_addr }}"`, defaulting to `https://{{ ansible_default_ipv4.address }}:8201` — each node advertises its own reachable `:8201` cluster listener. Cluster forwarding uses Vault's internal cluster TLS (not the public `*.jitsi.net` listener cert), so an IP is fine.

---

# ROLLOUT & TEST PLAN (handoff — safe to take over in a fresh session)

> Author paused before rollout (PTO). Everything below is self-contained. Related memory: `project_vault_seal_outage`. Parent tracking: JIT-16169; this change: **JIT-16171**.

## State of the world at handoff (2026-07-31)
- The seal-watchdog (with the 474 no-op fix, #940) and the consul-vault service are **deployed and confirmed on all 3 ops-prod vault nodes**: `10.34.136.43` + `10.34.139.48` (us-phoenix-1), `10.36.181.97` (eu-frankfurt-1).
- cloudprober `vault_nodes` probe is live and **green in both regions** (`cloudprober_failure=0`, `validation_failure=0`); the validator accepts `200-299,429,472,473,474` (#1133 merged).
- The `Vault_Node_Sealed_Or_Down` alert is a **page candidate** (`severity: severe`, no `page: true` yet).
- **This PR is the only remaining change that restarts vault** — all prior changes were no-op re-templates. Handle accordingly.

## Critical facts / gotchas
- **This changes `vault.hcl` → vault restarts on apply.** With auto-unseal (ocikms) a restart re-unseals in ~5s, but roll out **standby-first** and `vault operator step-down` the active before touching it.
- Supply the node's real seal vars as `--extra-vars` so the dry-run diff is **exactly one added line** (`cluster_addr`) and nothing else. Get them from the node: `sudo grep -E "key_id|crypto_endpoint|management_endpoint" /etc/vault.d/vault.hcl`. phx and fra use **different** KMS keys — gather per region.
- Cluster traffic uses Vault's internal cluster TLS, so the IP in `cluster_addr` needs no matching public cert.
- **ops-dev is single-node**, so it cannot exercise the standby→active forwarding path. Validation requires a 2-node cluster (scale ops-dev to 2, below).
- Run from the ops-agent container (overlays customizations on configuration) with `-i "<ip>," -u $SSH_USER --tags vault,consul-vault --vault-password-file ./.vault-password.txt`.

## Phase 0 — merge this PR to main
Safe: it only changes a default. Existing nodes don't restart until someone runs the apply; a **newly provisioned** node will pick up the correct `cluster_addr` at boot. Merge before scaling ops-dev so the new ops-dev node gets it.

## Phase 1 — validate on ops-dev (single node → scale to 2)
1. Apply to the existing ops-dev node `10.35.176.202` (on-box or from ops-agent):
   ```
   NODE=10.35.176.202; REGION=us-phoenix-1
   KID=$(ssh $SSH_USER@$NODE 'sudo grep key_id /etc/vault.d/vault.hcl | grep -oE "ocid1[^\"]+"')
   CRY=$(ssh $SSH_USER@$NODE 'sudo grep crypto_endpoint /etc/vault.d/vault.hcl | grep -oE "https://[^\"]+"')
   MGT=$(ssh $SSH_USER@$NODE 'sudo grep management_endpoint /etc/vault.d/vault.hcl | grep -oE "https://[^\"]+"')
   EV="hcv_environment=ops-dev oracle_region=$REGION region=$REGION cloud_provider=oracle cloud_name=$REGION-ops-dev-oracle vault_key_id=$KID vault_crypto_endpoint=$CRY vault_management_endpoint=$MGT vault_vector_enabled=false telegraf_enabled=false carbon_black_install_flag=false"
   # dry run: 'Install vault server configuration' now shows CHANGED with a one-line diff (+ cluster_addr). Confirm it's ONLY that line.
   ansible-playbook -i "$NODE," -u "$SSH_USER" --tags vault,consul-vault --check --diff --vault-password-file ./.vault-password.txt --extra-vars "$EV" ansible/configure-vault-local.yml
   # real run (vault restarts, auto-unseals as active)
   ansible-playbook -i "$NODE," -u "$SSH_USER" --tags vault,consul-vault --vault-password-file ./.vault-password.txt --extra-vars "$EV" ansible/configure-vault-local.yml
   ```
   Verify single node healthy: `vault status` → Sealed=false, HA active; startup log `Cluster Address:` now shows the node's own `:8201` (not `...:444`).
2. Scale the ops-dev vault instance pool to 2 (creates a standby that shares the OCI storage + KMS and auto-unseals at boot):
   ```
   POOL_ID=$(oci compute-management instance-pool list --compartment-id <ops-dev-compartment-ocid> --region us-phoenix-1 --display-name "ops-dev-us-phoenix-1-vault-InstancePool-0" --query "data[0].id" --raw-output)
   oci compute-management instance-pool update --instance-pool-id $POOL_ID --size 2
   ```
   (Canonical alternative: re-run `terraform/vault-server/create-oci-vault.sh` for ops-dev with `INSTANCE_POOL_SIZE=2` to keep tfstate in sync.) Wait for the new node's cloud-init to finish and it to auto-unseal + join as standby.
3. **Success criteria (the actual test):** on the new standby node:
   - `vault status` → Sealed=false, HA **standby**; the other node **active**.
   - `curl -sk https://127.0.0.1:8200/v1/sys/health` returns **429** (NOT 474), and the JSON shows `ha_connection_healthy: true` with a small/stable `last_request_forwarding_heartbeat_ms`.
   - `Cluster Address:` in each node's startup log = its own IP `:8201`.
4. Scale ops-dev back to 1 when done (`oci ... instance-pool update --size 1`, or TF with `INSTANCE_POOL_SIZE=1`) to restore normal ops-dev.

## Phase 2 — roll out to ops-prod (standby-first, this restarts vault)
Re-confirm current roles first (they drift): `vault status -tls-skip-verify | grep -E "Sealed|HA Mode"` on 136.43 + 139.48.
1. **Standby node** (whichever is standby): gather seal vars (REGION=us-phoenix-1), dry-run (confirm one-line cluster_addr diff), real run → vault restarts → auto-unseals → rejoins as standby. Verify health now returns **429** and `ha_connection_healthy: true`.
2. `ssh $SSH_USER@<active-ip> 'sudo VAULT_ADDR=https://127.0.0.1:8200 vault operator step-down'` (needs a token) → failover to the updated node.
3. Re-check roles, then apply to the now-standby node the same way.
4. **fra** `10.36.181.97` (single active node): gather seal vars with REGION=eu-frankfurt-1, apply (brief restart, re-unseals as active), verify healthy.

## Overall success criteria
- All 3 prod nodes: startup `Cluster Address` = own IP `:8201`; a standby returns `429` (not `474`); `ha_connection_healthy: true`.
- cloudprober `vault_nodes` still green (now 429 on standby, which the validator already accepts).
- Seal-watchdog remains a no-op on all nodes (429/200 healthy).

## Rollback (per node; restores the benign pre-fix state)
Revert this PR on main (or set `vault_server_cluster_addr` back to the old derived value) and re-run `configure-vault-local.yml` on the node → vault restarts with `cluster_addr` derived again (LB `:444`). Forwarding returns to non-working but the cluster keeps operating exactly as it did before this work.

## After success
- Good moment to flip `Vault_Node_Sealed_Or_Down` to `page: true` (474 gone → first paging state is unambiguous). One-line change in `infra-customizations-private/sites/ops-prod/vars.yml`.
- Close JIT-16171.