### PR TITLE
feat: Set jicofo max-bridge-participants-per-interval to 30

### DIFF
--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -56,6 +56,12 @@ jicofo_jvb_brewery_muc: JvbBrewery@{{ jicofo_internal_muc_prefix }}.{{ environme
 jicofo_max_audio_senders: 999999
 # Max participants in a single conference on a single bridge.
 jicofo_max_bridge_participants: 80
+# The interval for jicofo_max_bridge_participants_per_interval.
+jicofo_max_bridge_participants_interval: 1 minute
+# Max participants that a single conference may add to a single bridge within
+# jicofo_max_bridge_participants_interval (-1 to disable). This limits the overshoot when a conference bursts, because
+# the stress level reported by a bridge lags the actual load by 5-10 seconds.
+jicofo_max_bridge_participants_per_interval: 30
 jicofo_max_memory: "1536m"
 jicofo_max_video_senders: 999999
 jicofo_prosody_jvb_hostname: "127.0.0.1"

--- a/ansible/roles/jicofo/templates/jicofo.conf.j2
+++ b/ansible/roles/jicofo/templates/jicofo.conf.j2
@@ -32,6 +32,8 @@ jicofo {
     average-participant-stress = {{ jicofo_average_participant_stress }}
     stress-threshold = {{ jicofo_stress_threshold }}
     max-bridge-participants = {{ jicofo_max_bridge_participants }}
+    max-bridge-participants-per-interval = {{ jicofo_max_bridge_participants_per_interval }}
+    max-bridge-participants-interval = {{ jicofo_max_bridge_participants_interval }}
 
     # This duplicates oracle_to_aws_region_map and aws_to_oracle_region_map.
     # Once we're moved to oracle regions everywhere we should remove the extra mappings.


### PR DESCRIPTION
Enables the new jicofo per-conference bridge join-rate limit everywhere, via two new role variables:

- `jicofo_max_bridge_participants_per_interval`, default **30** (the feature is on by default, use -1 to disable)
- `jicofo_max_bridge_participants_interval`, default `1 minute`

They render as `jicofo.bridge.max-bridge-participants-per-interval` / `max-bridge-participants-interval` in `jicofo.conf`.

A bridge reports its stress level only every 5-10 seconds, so during a burst of joins the reported stress is stale and jicofo keeps assigning to the same bridge long after it is full. Seen in production: a conference added 92 endpoints in 31 seconds, 58 of them on one bridge which reached a stress of 1.1, while 9-11 bridges in the same pool stayed below 0.05. The limit caps how many endpoints a single conference may add to a single bridge per interval, which spreads the burst. A conference which grows slowly, and many small conferences sharing a bridge, are unaffected.

Requires jitsi/jicofo#1298. Older jicofo versions ignore the unknown keys.
