### PR TITLE
Add enableIceRestart and enableIceRestartOnNetworkChange config.js flags

### DIFF
--- a/ansible/roles/jitsi-meet/defaults/main.yml
+++ b/ansible/roles/jitsi-meet/defaults/main.yml
@@ -154,6 +154,8 @@ jitsi_meet_enable_file_recordings_sharing: false
 jitsi_meet_enable_forced_client_reload: false
 jitsi_meet_enable_graceful_reconnect: false
 jitsi_meet_enable_gzip: false
+jitsi_meet_enable_ice_restart: false
+jitsi_meet_enable_ice_restart_on_network_change: false
 jitsi_meet_enable_insecure_room_name_warning: false
 jitsi_meet_enable_livestreaming: false
 jitsi_meet_enable_local_video_flip: true

--- a/ansible/roles/jitsi-meet/templates/config.js.j2
+++ b/ansible/roles/jitsi-meet/templates/config.js.j2
@@ -90,6 +90,8 @@ var config = {
     {% endif %}
 },
     enableP2P: {% if jitsi_meet_enable_p2p %}true{% else %}false{% endif %}, // flag to control P2P connections
+    enableIceRestart: {% if jitsi_meet_enable_ice_restart %}true{% else %}false{% endif %},
+    enableIceRestartOnNetworkChange: {% if jitsi_meet_enable_ice_restart_on_network_change %}true{% else %}false{% endif %},
     // New P2P options
     p2p: {
         enabled: {% if jitsi_meet_enable_p2p %}true{% else %}false{% endif %},


### PR DESCRIPTION
Adds Ansible role defaults and config.js.j2 rendering for two jitsi-meet config flags: `enableIceRestart`, `enableIceRestartOnNetworkChange`. Both default false.