### PR TITLE
fix: add ::1 to the prosody rate limit whitelist

### DIFF
--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -230,8 +230,8 @@ prosody_rate_limit_cache_size: 10000
 prosody_rate_limit_login_rate: 3
 prosody_rate_limit_session_rate: 2000
 prosody_rate_limit_timeout: 60
-# whitelist localhost, internal network
-prosody_rate_limit_whitelist: ["127.0.0.1", "10.0.0.0/8"]
+# whitelist localhost (IPv4 and IPv6), internal network
+prosody_rate_limit_whitelist: ["127.0.0.1", "::1", "10.0.0.0/8"]
 prosody_rate_limit_host_whitelist:
   - "recorder.{{ prosody_domain_name }}"
 prosody_region: "{{ ansible_ec2_placement_region if ansible_ec2_placement_region is defined and ansible_ec2_placement_region


### PR DESCRIPTION
`prosody_rate_limit_whitelist` had only IPv4 entries. The main prosody and a visitor node on the same host connect over the IPv6 loopback address, so the s2s link between them was rate limited.

### Related

Parts of the same fix:

- jitsi/jitsi-meet#17739 - do not rate limit s2s sessions
- jitsi/docker-jitsi-meet#2309 - add `::1` to the whitelist in the prosody templates
- jitsi/infra-configuration#944 - add `::1` to the ansible default whitelist
- jitsi/infra-provisioning#1139 - set the session rate on the visitor node task
