### PR TITLE
fix(terminate): retry in a loop instead of recursing, self-heal OCI connectivity

### DIFF
--- a/ansible/roles/autoscaler-sidecar/files/terminate_instance_oracle.sh
+++ b/ansible/roles/autoscaler-sidecar/files/terminate_instance_oracle.sh
@@ -33,17 +33,27 @@ function restore_oci_connectivity() {
     fi
     echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
     /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
-    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
-    secondary_device="${secondary_device::-1}"
-    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # find the device holding the secondary IP rather than guessing from the
+    # interface list, which can pick a veth device on hosts running workloads
+    local secondary_device="$(ip -o addr show | awk -v ip="$secondary_ip" '$3 == "inet" && index($4, ip"/") == 1 {print $2}' | head -1)"
+    if [ -z "$secondary_device" ]; then
+        echo "No device holds secondary IP $secondary_ip, leaving routes untouched"
+        return 1
+    fi
+    # compute and validate the new default route BEFORE deleting the existing
+    # ones, so a failure here cannot leave the host with no default route
+    local nic2_gateway="$(ip route show | grep "dev $secondary_device" | grep -v default | head -1 | awk '{ print substr($1,1,index($1,"/")-2)1 }')"
+    if [ -z "$nic2_gateway" ]; then
+        echo "Unable to determine gateway via $secondary_device, leaving routes untouched"
+        return 1
+    fi
     # replace any existing default routes with one via the secondary VNIC
     local default_route="$(ip route show | grep default -m 1)"
     while [ -n "$default_route" ]; do
         ip route delete $default_route || return 1
         default_route="$(ip route show | grep default -m 1)"
     done
-    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
-    ip route add $nic2_route
+    ip route add default via $nic2_gateway dev $secondary_device
 }
 
 function default_terminate() {

--- a/ansible/roles/autoscaler-sidecar/files/terminate_instance_oracle.sh
+++ b/ansible/roles/autoscaler-sidecar/files/terminate_instance_oracle.sh
@@ -12,16 +12,54 @@ if [ -z "$INSTANCE_ID" ]; then
     INSTANCE_ID=$($CURL_BIN -s http://169.254.169.254/opc/v1/instance/ | $JQ_BIN .id -r)
 fi
 
-function default_terminate() {
-    echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
-    $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
-    RET=$?
-    # infinite loop on failure
-    if [ $RET -gt 0 ]; then
-        echo "Failed to terminate instance, exit code: $RET, sleeping 10 then retrying"
-        sleep 10
-        default_terminate
+function oci_api_reachable() {
+    local region=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
+    local http_code=$($CURL_BIN -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
+    if [ "$http_code" == "000" ]; then
+        echo "OCI API auth endpoint for region $region is not reachable"
+        return 1
     fi
+    return 0
+}
+
+function restore_oci_connectivity() {
+    # the OCI API is unreachable when the instance has no public IP (e.g. a
+    # boot that failed before one was attached); a secondary VNIC can appear
+    # in instance metadata late, so re-check for one and route through it
+    local secondary_ip=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/ | jq -r '.[1].privateIp')
+    if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
+        echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
+        return 1
+    fi
+    echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
+    /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
+    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
+    secondary_device="${secondary_device::-1}"
+    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # replace any existing default routes with one via the secondary VNIC
+    local default_route="$(ip route show | grep default -m 1)"
+    while [ -n "$default_route" ]; do
+        ip route delete $default_route || return 1
+        default_route="$(ip route show | grep default -m 1)"
+    done
+    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
+    ip route add $nic2_route
+}
+
+function default_terminate() {
+    # retry in a loop rather than recursing: recursion eventually overflows
+    # the stack and segfaults, silently ending the retries. The instance is
+    # deliberately left RUNNING while retries continue so the autoscaler
+    # counts it as untracked and an operator can intervene.
+    while true; do
+        if ! oci_api_reachable; then
+            restore_oci_connectivity
+        fi
+        echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
+        $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force && break
+        echo "Failed to terminate instance, sleeping 10 then retrying"
+        sleep 10
+    done
 }
 
 # now terminate our instance

--- a/ansible/roles/jibri-java/templates/terminate_instance_oracle.j2
+++ b/ansible/roles/jibri-java/templates/terminate_instance_oracle.j2
@@ -50,17 +50,27 @@ function restore_oci_connectivity() {
     fi
     echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
     /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
-    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
-    secondary_device="${secondary_device::-1}"
-    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # find the device holding the secondary IP rather than guessing from the
+    # interface list, which can pick a veth device on hosts running workloads
+    local secondary_device="$(ip -o addr show | awk -v ip="$secondary_ip" '$3 == "inet" && index($4, ip"/") == 1 {print $2}' | head -1)"
+    if [ -z "$secondary_device" ]; then
+        echo "No device holds secondary IP $secondary_ip, leaving routes untouched"
+        return 1
+    fi
+    # compute and validate the new default route BEFORE deleting the existing
+    # ones, so a failure here cannot leave the host with no default route
+    local nic2_gateway="$(ip route show | grep "dev $secondary_device" | grep -v default | head -1 | awk '{ print substr($1,1,index($1,"/")-2)1 }')"
+    if [ -z "$nic2_gateway" ]; then
+        echo "Unable to determine gateway via $secondary_device, leaving routes untouched"
+        return 1
+    fi
     # replace any existing default routes with one via the secondary VNIC
     local default_route="$(ip route show | grep default -m 1)"
     while [ -n "$default_route" ]; do
         ip route delete $default_route || return 1
         default_route="$(ip route show | grep default -m 1)"
     done
-    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
-    ip route add $nic2_route
+    ip route add default via $nic2_gateway dev $secondary_device
 }
 
 function default_terminate() {

--- a/ansible/roles/jibri-java/templates/terminate_instance_oracle.j2
+++ b/ansible/roles/jibri-java/templates/terminate_instance_oracle.j2
@@ -29,16 +29,54 @@ service consul stop
 $CURL_BIN -d '{}' -v localhost:6000/hook/v1/shutdown
 sleep 10
 
-function default_terminate() {
-    echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
-    $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
-    RET=$?
-    # infinite loop on failure
-    if [ $RET -gt 0 ]; then
-        echo "Failed to terminate instance, exit code: $RET, sleeping 10 then retrying"
-        sleep 10
-        default_terminate
+function oci_api_reachable() {
+    local region=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
+    local http_code=$($CURL_BIN -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
+    if [ "$http_code" == "000" ]; then
+        echo "OCI API auth endpoint for region $region is not reachable"
+        return 1
     fi
+    return 0
+}
+
+function restore_oci_connectivity() {
+    # the OCI API is unreachable when the instance has no public IP (e.g. a
+    # boot that failed before one was attached); a secondary VNIC can appear
+    # in instance metadata late, so re-check for one and route through it
+    local secondary_ip=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/ | jq -r '.[1].privateIp')
+    if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
+        echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
+        return 1
+    fi
+    echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
+    /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
+    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
+    secondary_device="${secondary_device::-1}"
+    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # replace any existing default routes with one via the secondary VNIC
+    local default_route="$(ip route show | grep default -m 1)"
+    while [ -n "$default_route" ]; do
+        ip route delete $default_route || return 1
+        default_route="$(ip route show | grep default -m 1)"
+    done
+    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
+    ip route add $nic2_route
+}
+
+function default_terminate() {
+    # retry in a loop rather than recursing: recursion eventually overflows
+    # the stack and segfaults, silently ending the retries. The instance is
+    # deliberately left RUNNING while retries continue so the autoscaler
+    # counts it as untracked and an operator can intervene.
+    while true; do
+        if ! oci_api_reachable; then
+            restore_oci_connectivity
+        fi
+        echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
+        $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force && break
+        echo "Failed to terminate instance, sleeping 10 then retrying"
+        sleep 10
+    done
 }
 
 # now terminate our instance

--- a/ansible/roles/jigasi/templates/terminate_instance_oracle.j2
+++ b/ansible/roles/jigasi/templates/terminate_instance_oracle.j2
@@ -35,17 +35,27 @@ function restore_oci_connectivity() {
     fi
     echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
     /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
-    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
-    secondary_device="${secondary_device::-1}"
-    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # find the device holding the secondary IP rather than guessing from the
+    # interface list, which can pick a veth device on hosts running workloads
+    local secondary_device="$(ip -o addr show | awk -v ip="$secondary_ip" '$3 == "inet" && index($4, ip"/") == 1 {print $2}' | head -1)"
+    if [ -z "$secondary_device" ]; then
+        echo "No device holds secondary IP $secondary_ip, leaving routes untouched"
+        return 1
+    fi
+    # compute and validate the new default route BEFORE deleting the existing
+    # ones, so a failure here cannot leave the host with no default route
+    local nic2_gateway="$(ip route show | grep "dev $secondary_device" | grep -v default | head -1 | awk '{ print substr($1,1,index($1,"/")-2)1 }')"
+    if [ -z "$nic2_gateway" ]; then
+        echo "Unable to determine gateway via $secondary_device, leaving routes untouched"
+        return 1
+    fi
     # replace any existing default routes with one via the secondary VNIC
     local default_route="$(ip route show | grep default -m 1)"
     while [ -n "$default_route" ]; do
         ip route delete $default_route || return 1
         default_route="$(ip route show | grep default -m 1)"
     done
-    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
-    ip route add $nic2_route
+    ip route add default via $nic2_gateway dev $secondary_device
 }
 
 function default_terminate() {

--- a/ansible/roles/jigasi/templates/terminate_instance_oracle.j2
+++ b/ansible/roles/jigasi/templates/terminate_instance_oracle.j2
@@ -14,16 +14,54 @@ $CURL_BIN -d '{}' -v localhost:6000/hook/v1/shutdown
 sleep 10
 
 
-function default_terminate() {
-    echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
-    $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
-    RET=$?
-    # infinite loop on failure
-    if [ $RET -gt 0 ]; then
-        echo "Failed to terminate instance, exit code: $RET, sleeping 10 then retrying"
-        sleep 10
-        default_terminate
+function oci_api_reachable() {
+    local region=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
+    local http_code=$($CURL_BIN -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
+    if [ "$http_code" == "000" ]; then
+        echo "OCI API auth endpoint for region $region is not reachable"
+        return 1
     fi
+    return 0
+}
+
+function restore_oci_connectivity() {
+    # the OCI API is unreachable when the instance has no public IP (e.g. a
+    # boot that failed before one was attached); a secondary VNIC can appear
+    # in instance metadata late, so re-check for one and route through it
+    local secondary_ip=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/ | jq -r '.[1].privateIp')
+    if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
+        echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
+        return 1
+    fi
+    echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
+    /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
+    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
+    secondary_device="${secondary_device::-1}"
+    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # replace any existing default routes with one via the secondary VNIC
+    local default_route="$(ip route show | grep default -m 1)"
+    while [ -n "$default_route" ]; do
+        ip route delete $default_route || return 1
+        default_route="$(ip route show | grep default -m 1)"
+    done
+    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
+    ip route add $nic2_route
+}
+
+function default_terminate() {
+    # retry in a loop rather than recursing: recursion eventually overflows
+    # the stack and segfaults, silently ending the retries. The instance is
+    # deliberately left RUNNING while retries continue so the autoscaler
+    # counts it as untracked and an operator can intervene.
+    while true; do
+        if ! oci_api_reachable; then
+            restore_oci_connectivity
+        fi
+        echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
+        $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force && break
+        echo "Failed to terminate instance, sleeping 10 then retrying"
+        sleep 10
+    done
 }
 
 # now terminate our instance

--- a/ansible/roles/jitsi-videobridge/templates/terminate_instance_oracle.j2
+++ b/ansible/roles/jitsi-videobridge/templates/terminate_instance_oracle.j2
@@ -42,17 +42,27 @@ function restore_oci_connectivity() {
     fi
     echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
     /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
-    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
-    secondary_device="${secondary_device::-1}"
-    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # find the device holding the secondary IP rather than guessing from the
+    # interface list, which can pick a veth device on hosts running workloads
+    local secondary_device="$(ip -o addr show | awk -v ip="$secondary_ip" '$3 == "inet" && index($4, ip"/") == 1 {print $2}' | head -1)"
+    if [ -z "$secondary_device" ]; then
+        echo "No device holds secondary IP $secondary_ip, leaving routes untouched"
+        return 1
+    fi
+    # compute and validate the new default route BEFORE deleting the existing
+    # ones, so a failure here cannot leave the host with no default route
+    local nic2_gateway="$(ip route show | grep "dev $secondary_device" | grep -v default | head -1 | awk '{ print substr($1,1,index($1,"/")-2)1 }')"
+    if [ -z "$nic2_gateway" ]; then
+        echo "Unable to determine gateway via $secondary_device, leaving routes untouched"
+        return 1
+    fi
     # replace any existing default routes with one via the secondary VNIC
     local default_route="$(ip route show | grep default -m 1)"
     while [ -n "$default_route" ]; do
         ip route delete $default_route || return 1
         default_route="$(ip route show | grep default -m 1)"
     done
-    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
-    ip route add $nic2_route
+    ip route add default via $nic2_gateway dev $secondary_device
 }
 
 function default_terminate() {

--- a/ansible/roles/jitsi-videobridge/templates/terminate_instance_oracle.j2
+++ b/ansible/roles/jitsi-videobridge/templates/terminate_instance_oracle.j2
@@ -21,16 +21,54 @@ service consul stop
 $CURL_BIN -d '{}' -v localhost:6000/hook/v1/shutdown
 sleep 10
 
-function default_terminate() {
-    echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
-    $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
-    RET=$?
-    # infinite loop on failure
-    if [ $RET -gt 0 ]; then
-        echo "Failed to terminate instance, exit code: $RET, sleeping 10 then retrying"
-        sleep 10
-        default_terminate
+function oci_api_reachable() {
+    local region=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
+    local http_code=$($CURL_BIN -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
+    if [ "$http_code" == "000" ]; then
+        echo "OCI API auth endpoint for region $region is not reachable"
+        return 1
     fi
+    return 0
+}
+
+function restore_oci_connectivity() {
+    # the OCI API is unreachable when the instance has no public IP (e.g. a
+    # boot that failed before one was attached); a secondary VNIC can appear
+    # in instance metadata late, so re-check for one and route through it
+    local secondary_ip=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/ | jq -r '.[1].privateIp')
+    if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
+        echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
+        return 1
+    fi
+    echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
+    /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
+    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
+    secondary_device="${secondary_device::-1}"
+    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # replace any existing default routes with one via the secondary VNIC
+    local default_route="$(ip route show | grep default -m 1)"
+    while [ -n "$default_route" ]; do
+        ip route delete $default_route || return 1
+        default_route="$(ip route show | grep default -m 1)"
+    done
+    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
+    ip route add $nic2_route
+}
+
+function default_terminate() {
+    # retry in a loop rather than recursing: recursion eventually overflows
+    # the stack and segfaults, silently ending the retries. The instance is
+    # deliberately left RUNNING while retries continue so the autoscaler
+    # counts it as untracked and an operator can intervene.
+    while true; do
+        if ! oci_api_reachable; then
+            restore_oci_connectivity
+        fi
+        echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
+        $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force && break
+        echo "Failed to terminate instance, sleeping 10 then retrying"
+        sleep 10
+    done
 }
 
 # now terminate our instance

--- a/ansible/roles/nomad-jitsi/templates/nomad_terminate_instance_oracle.sh.j2
+++ b/ansible/roles/nomad-jitsi/templates/nomad_terminate_instance_oracle.sh.j2
@@ -39,17 +39,27 @@ function restore_oci_connectivity() {
     fi
     echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
     /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
-    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
-    secondary_device="${secondary_device::-1}"
-    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # find the device holding the secondary IP rather than guessing from the
+    # interface list, which can pick a veth device on hosts running workloads
+    local secondary_device="$(ip -o addr show | awk -v ip="$secondary_ip" '$3 == "inet" && index($4, ip"/") == 1 {print $2}' | head -1)"
+    if [ -z "$secondary_device" ]; then
+        echo "No device holds secondary IP $secondary_ip, leaving routes untouched"
+        return 1
+    fi
+    # compute and validate the new default route BEFORE deleting the existing
+    # ones, so a failure here cannot leave the host with no default route
+    local nic2_gateway="$(ip route show | grep "dev $secondary_device" | grep -v default | head -1 | awk '{ print substr($1,1,index($1,"/")-2)1 }')"
+    if [ -z "$nic2_gateway" ]; then
+        echo "Unable to determine gateway via $secondary_device, leaving routes untouched"
+        return 1
+    fi
     # replace any existing default routes with one via the secondary VNIC
     local default_route="$(ip route show | grep default -m 1)"
     while [ -n "$default_route" ]; do
         ip route delete $default_route || return 1
         default_route="$(ip route show | grep default -m 1)"
     done
-    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
-    ip route add $nic2_route
+    ip route add default via $nic2_gateway dev $secondary_device
 }
 
 function default_terminate() {

--- a/ansible/roles/nomad-jitsi/templates/nomad_terminate_instance_oracle.sh.j2
+++ b/ansible/roles/nomad-jitsi/templates/nomad_terminate_instance_oracle.sh.j2
@@ -18,16 +18,54 @@ sudo service consul stop
 $CURL_BIN -d '{}' -v localhost:6000/hook/v1/shutdown
 sleep 10
 
-function default_terminate() {
-    echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
-    $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force
-    RET=$?
-    # infinite loop on failure
-    if [ $RET -gt 0 ]; then
-        echo "Failed to terminate instance, exit code: $RET, sleeping 10 then retrying"
-        sleep 10
-        default_terminate
+function oci_api_reachable() {
+    local region=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/instance/ | jq -r .canonicalRegionName)
+    local http_code=$($CURL_BIN -s -m 10 -o /dev/null -w '%{http_code}' "https://auth.${region}.oraclecloud.com/v1/x509")
+    if [ "$http_code" == "000" ]; then
+        echo "OCI API auth endpoint for region $region is not reachable"
+        return 1
     fi
+    return 0
+}
+
+function restore_oci_connectivity() {
+    # the OCI API is unreachable when the instance has no public IP (e.g. a
+    # boot that failed before one was attached); a secondary VNIC can appear
+    # in instance metadata late, so re-check for one and route through it
+    local secondary_ip=$($CURL_BIN --connect-timeout 10 -s http://169.254.169.254/opc/v1/vnics/ | jq -r '.[1].privateIp')
+    if [ -z "$secondary_ip" ] || [ "$secondary_ip" == "null" ]; then
+        echo "No secondary VNIC in metadata, unable to restore OCI API connectivity"
+        return 1
+    fi
+    echo "Secondary VNIC with IP $secondary_ip found, configuring and routing through it to reach the OCI API"
+    /usr/local/bin/secondary_vnic_all_configure_oracle.sh -c || return 1
+    local secondary_device="$(ip addr | egrep '^[0-9]' | egrep -v 'lo|docker' | tail -1 | awk '{print $2}')"
+    secondary_device="${secondary_device::-1}"
+    secondary_device="$(echo $secondary_device | cut -d'@' -f1)"
+    # replace any existing default routes with one via the secondary VNIC
+    local default_route="$(ip route show | grep default -m 1)"
+    while [ -n "$default_route" ]; do
+        ip route delete $default_route || return 1
+        default_route="$(ip route show | grep default -m 1)"
+    done
+    local nic2_route="default via "$(ip route show | grep $secondary_device | awk '{ print substr($1,1,index($1,"/")-2)1 " " $2 " " $3}' | head -1)
+    ip route add $nic2_route
+}
+
+function default_terminate() {
+    # retry in a loop rather than recursing: recursion eventually overflows
+    # the stack and segfaults, silently ending the retries. The instance is
+    # deliberately left RUNNING while retries continue so the autoscaler
+    # counts it as untracked and an operator can intervene.
+    while true; do
+        if ! oci_api_reachable; then
+            restore_oci_connectivity
+        fi
+        echo "Terminate the instance; we enable debug to have more details in case of oci cli failures"
+        $OCI_BIN compute instance terminate --debug --instance-id "$INSTANCE_ID" --preserve-boot-volume false --auth instance_principal --force && break
+        echo "Failed to terminate instance, sleeping 10 then retrying"
+        sleep 10
+    done
 }
 
 # now terminate our instance


### PR DESCRIPTION
Companion to jitsi/infra-provisioning#1140 — see that PR for the full incident analysis.

## Problem

A JVB in ap-mumbai-1 (`10.62.122.163`) failed to boot on 2026-08-20 because the OCI metadata service reported the secondary VNIC 12+ minutes late, so no public IP was ever attached and the OCI API was unreachable. The image's `/usr/local/bin/terminate_instance.sh` then retried termination via **infinite recursion**; after ~72 hours (~3,400 stack frames) bash segfaulted (`Segmentation fault (core dumped)`), silently ending all retries and leaving a zombie RUNNING instance.

The same recursive `default_terminate` exists in five oracle terminate scripts (jvb, jibri, jigasi, nomad-jitsi, autoscaler-sidecar).

## Changes (identical in all five scripts)

- retry termination in a `while` loop instead of recursing — no stack growth, no segfault
- before each attempt, probe the regional OCI auth endpoint (`oci_api_reachable`); if unreachable, `restore_oci_connectivity` re-checks metadata for a late-appearing secondary VNIC, configures it (`secondary_vnic_all_configure_oracle.sh -c`) and switches the default route through it, mirroring the route-switch logic in infra-provisioning's `postinstall-eip-lib.sh`. On the incident instance this would have terminated it as soon as the metadata caught up instead of looping blind for 3 days.
- the instance is deliberately left RUNNING while retries continue (no shutdown), so the autoscaler counts it as untracked and an operator can intervene

Notes:
- the connectivity-restore route changes need root; in the graceful scale-down path (run as `jsidecar`) networking is healthy so the probe passes and the restore is never attempted
- all five scripts pass `bash -n`
- pre-existing oddity left untouched: `jibri-java`'s script computes `PRESERVE_BOOT_VOLUME` from recording dirs but still hardcodes `--preserve-boot-volume false`