### PR TITLE
feat: optional OTLP distributed tracing for VM jicofo + jvb + prosody

### DIFF
--- a/ansible/roles/jicofo/defaults/main.yml
+++ b/ansible/roles/jicofo/defaults/main.yml
@@ -1,6 +1,13 @@
 ---
 jicofo_auth_domain: "auth.{{ environment_domain_name | default('domain.local') }}"
 jicofo_auth_password: "{{ secrets_jicofo_focus | default('replaceme') }}"
+
+# Distributed tracing (OTLP export to the regional alloy -otel collector, which
+# forwards to Tempo). Gated on the shared tracing_enabled site var -- the same
+# flag the nomad jitsi_meet_backend/jvb packs use. Default off.
+jicofo_tracing_enabled: "{{ tracing_enabled | default(false) }}"
+jicofo_tracing_protocol: "{{ tracing_protocol | default('http') }}"
+jicofo_tracing_otlp_endpoint: "{{ tracing_otlp_endpoint | default('https://' ~ hcv_environment ~ '-' ~ oracle_region ~ '-otel.' ~ (top_level_domain | default('jitsi.net'))) }}"
 jicofo_auth_password_jvb: "{{ secrets_jicofo_focus_jvb | default('replaceme') }}"
 jicofo_auth_password_visitor: "{{ secrets_jicofo_focus_visitor | default('replaceme') }}"
 jicofo_auth_type: XMPP

--- a/ansible/roles/jicofo/templates/jicofo.conf.j2
+++ b/ansible/roles/jicofo/templates/jicofo.conf.j2
@@ -240,3 +240,14 @@ jicofo {
 {% endif %}
   }
 }
+{% if jicofo_tracing_enabled | bool %}
+
+# Distributed tracing: export OTLP spans to the regional alloy (-otel), which
+# forwards to Tempo. jicoco's HTTP OTLP exporter needs the full /v1/traces URL;
+# grpc takes host:port.
+tracing {
+    enabled = true
+    otlp-protocol = "{{ jicofo_tracing_protocol }}"
+    otlp-endpoint = "{{ jicofo_tracing_otlp_endpoint }}{% if jicofo_tracing_protocol == 'http' %}/v1/traces{% endif %}"
+}
+{% endif %}

--- a/ansible/roles/jitsi-videobridge/defaults/main.yml
+++ b/ansible/roles/jitsi-videobridge/defaults/main.yml
@@ -1,6 +1,13 @@
 ---
 jitsi_videobridge_deb_pkg_name: "jitsi-videobridge2"
 jitsi_videobridge_deb_pkg_version: "*"
+
+# Distributed tracing (OTLP export to the regional alloy -otel collector, which
+# forwards to Tempo). Gated on the shared tracing_enabled site var -- the same
+# flag the nomad jitsi_meet_backend/jvb packs use. Default off.
+jvb_tracing_enabled: "{{ tracing_enabled | default(false) }}"
+jvb_tracing_protocol: "{{ tracing_protocol | default('http') }}"
+jvb_tracing_otlp_endpoint: "{{ tracing_otlp_endpoint | default('https://' ~ hcv_environment ~ '-' ~ oracle_region ~ '-otel.' ~ (top_level_domain | default('jitsi.net'))) }}"
 jitsi_videobridge_force_deb_pkg_version: false
 # Whether to make the jvb version known to clients
 jvb_announce_version: true

--- a/ansible/roles/jitsi-videobridge/templates/jvb.conf.j2
+++ b/ansible/roles/jitsi-videobridge/templates/jvb.conf.j2
@@ -237,3 +237,14 @@ ice4j {
 }
 
 include "xmpp.conf"
+
+{% if jvb_tracing_enabled | bool %}
+# Distributed tracing: export OTLP spans to the regional alloy (-otel), which
+# forwards to Tempo. jicoco's HTTP OTLP exporter needs the full /v1/traces URL;
+# grpc takes host:port.
+tracing {
+    enabled = true
+    otlp-protocol = "{{ jvb_tracing_protocol }}"
+    otlp-endpoint = "{{ jvb_tracing_otlp_endpoint }}{% if jvb_tracing_protocol == 'http' %}/v1/traces{% endif %}"
+}
+{% endif %}

--- a/ansible/roles/prosody/defaults/main.yml
+++ b/ansible/roles/prosody/defaults/main.yml
@@ -252,6 +252,14 @@ prosody_token_allow_empty: true
 prosody_visitor_token_allow_empty: true
 prosody_token_app_id: jitsi
 prosody_token_app_secret: false
+
+# Distributed tracing (OTLP export to the regional alloy -otel collector, which
+# forwards to Tempo). Gated on the shared tracing_enabled site var -- the same
+# flag the nomad jitsi_meet_backend/jvb packs and the jicofo/jvb roles use.
+# Default off. prosody's OTLP exporter is HTTP-only and appends /v1/traces
+# itself, so there is no protocol var (unlike jicofo/jvb).
+prosody_tracing_enabled: "{{ tracing_enabled | default(false) }}"
+prosody_tracing_otlp_endpoint: "{{ tracing_otlp_endpoint | default('https://' ~ hcv_environment ~ '-' ~ oracle_region ~ '-otel.' ~ (top_level_domain | default('jitsi.net'))) }}"
 # our networks and cloudflare ip-ranges (cloudflare ranges come from https://www.cloudflare.com/en-gb/ips/)
 prosody_trusted_proxies: [
   "127.0.0.1", "::1", "10.0.0.0/8", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22", "104.16.0.0/13", "104.24.0.0/14",

--- a/ansible/roles/prosody/templates/prosody-jvb.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody-jvb.cfg.lua.j2
@@ -123,6 +123,14 @@ log = {
 
 plugin_paths = { "{{ prosody_plugins_path }}/" }
 
+{% if prosody_tracing_enabled | bool %}
+-- Distributed tracing: export OTLP spans to the regional alloy (-otel), which
+-- forwards to Tempo. This brewery prosody hosts the JVB brewery MUC, where the
+-- jicofo->JVB colibri2 conference-modify IQs flow, so mod_trace on that MUC is
+-- what actually emits prosody spans. HTTP-only; the exporter appends /v1/traces.
+otlp_endpoint = "{{ prosody_tracing_otlp_endpoint }}/v1/traces"
+{% endif %}
+
 ----------- Virtual hosts -----------
 VirtualHost "{{ prosody_jvb_auth_domain_name }}"
     modules_enabled = {
@@ -141,6 +149,12 @@ Component "{{ prosody_jvb_muc_name }}" "muc"
       "ping",
 {% if prosody_hide_all_rooms %}
         "muc_hide_all";
+{% endif %}
+{% if prosody_tracing_enabled | bool %}
+      -- distributed tracing: the JVB brewery MUC carries the jicofo->JVB colibri2
+      -- conference-modify IQs, so mod_trace here emits the colibri spans that
+      -- stitch prosody into the jicofo/jvb traces.
+      "trace";
 {% endif %}
       "muc_filter_access";
     }

--- a/ansible/roles/prosody/templates/prosody.cfg.lua.j2
+++ b/ansible/roles/prosody/templates/prosody.cfg.lua.j2
@@ -407,6 +407,13 @@ token_verification_allowlist = {
 
 plugin_paths = { "{{ prosody_plugins_path }}/" }
 
+{% if prosody_tracing_enabled | bool %}
+-- Distributed tracing: export OTLP spans to the regional alloy (-otel), which
+-- forwards to Tempo. prosody's mod_trace/otel exporter is HTTP-only and appends
+-- /v1/traces itself. Gated on the shared tracing_enabled site var.
+otlp_endpoint = "{{ prosody_tracing_otlp_endpoint }}/v1/traces"
+{% endif %}
+
 ----------- Virtual hosts -----------
 VirtualHost "{{ prosody_domain_name }}"
         -- enabled = false -- Remove this line to enable this host
@@ -744,6 +751,10 @@ Component "internal.auth.{{ prosody_domain_name }}" "muc"
     modules_enabled = {
 {% if prosody_hide_all_rooms %}
       "muc_hide_all";
+{% endif %}
+{% if prosody_tracing_enabled | bool %}
+      -- distributed tracing (matches docker#2303, trace on the internal MUC)
+      "trace";
 {% endif %}
       "muc_filter_access";
     }


### PR DESCRIPTION
## What

Ports the distributed tracing we shipped for the Nomad packs (infra-provisioning #1150/#1155/#1156) to the **Ansible / VM** deployment. jicofo, jvb, and prosody export OTLP spans to the **regional alloy** (`<env>-<region>-otel`), which forwards to Tempo (internal per-env + external Grafana Cloud) — the same collector VMs already ship logs to via the `vector` role.

## How

- **Gated on `tracing_enabled`** — the shared `sites/<env>/vars.yml` flag (same file/flag the Nomad side reads), default **off**. Nothing renders unless an env opts in (currently just beta).
- **Endpoint** defaults to `https://{{ hcv_environment }}-{{ oracle_region }}-otel.{{ top_level_domain | default('jitsi.net') }}`, overridable via `tracing_otlp_endpoint`. `http` → full `/v1/traces` URL (jicoco `OtlpHttpSpanExporter`); `grpc` → host:port.
- **jicofo / jvb**: top-level `tracing {}` block in `jicofo.conf.j2` / `jvb.conf.j2`, plus role-defaults (`{jicofo,jvb}_tracing_{enabled,protocol,otlp_endpoint}`).
- **prosody**: global `otlp_endpoint = "<endpoint>/v1/traces"` + the `"trace"` module, in **both** prosody configs, plus role-defaults (`prosody_tracing_{enabled,otlp_endpoint}`; prosody's OTLP exporter is HTTP-only and appends `/v1/traces` itself, so no protocol var):
  - `prosody.cfg.lua.j2` — `"trace"` on the `internal.auth` MUC (matches docker#2303 exactly; upstream parity + non-split shards).
  - `prosody-jvb.cfg.lua.j2` — `"trace"` on the **`muc.jvb` brewery MUC**. This is the effective place: in our split-brewery topology the jicofo→JVB colibri2 `conference-modify` IQs (the only stanzas `mod_trace` spans) flow through the brewery prosody, not `internal.auth`. Without this the VM prosody emits no colibri spans.

## Testing

Rendered the endpoint + gate via ansible: `https://beta-meet-jit-si-<region>-otel.jitsi.net/v1/traces`; gate `True` when `tracing_enabled: true`, `False` when unset. Both `prosody*.cfg.lua.j2` parse cleanly under jinja2. Diff is additive-only, default-off so existing envs are unaffected. Confirmed on the live beta prosody image that `mod_trace.lua` + `otel.lib.lua` ship in the jitsi-meet-prosody deb (`/usr/share/jitsi-meet/prosody-plugins/`).

## Notes / follow-ups

- Requires jicofo/jitsi-videobridge2 deb packages that include the jicoco tracing code (same upstream builds as the verified docker images) — recent packages have it.
- **Nomad parity**: the nomad prosody has the same split-brewery gap — docker#2303 only trace-enabled the main prosody's internal MUC, so the brewery (`prosody-jvb`) needs the same `"trace"` addition in `docker-jitsi-meet`'s `brewery.cfg.lua` (separate PR + image roll; env-only/`GLOBAL_MODULES` can't reach the brewery MUC's `modules_enabled`).
- **Visitor** prosody (`prosody.cfg.lua.visitor.j2`) is intentionally left out — visitor MUCs aren't part of colibri signaling.
- Beta already has `tracing_enabled: true`, so a core/jvb/prosody config run will turn this on there.