### PR TITLE
feat(jitsi-meet): add audioTranslation duckedVolume and sending change events

### DIFF
--- a/ansible/roles/jitsi-meet/defaults/main.yml
+++ b/ansible/roles/jitsi-meet/defaults/main.yml
@@ -80,6 +80,7 @@ jitsi_meet_assetlinks: |
           "sha256_cert_fingerprints": ["F6:C8:93:15:16:9D:E0:08:0A:B7:EA:36:15:26:24:25:60:93:77:F7:61:79:89:E9:52:05:F4:09:B3:0E:59:44"]
       }
   }]
+jitsi_meet_audio_translation_ducked_volume: 0.15
 jitsi_meet_bosh_host: "{{ environment_domain_name }}"
 jitsi_meet_bosh_path: "http-bind"
 jitsi_meet_bosh_protocol: "https://"
@@ -137,7 +138,7 @@ jitsi_meet_dropbox_app_key: false
 jitsi_meet_dump_transcript: false
 jitsi_meet_e2eping_enabled: false
 jitsi_meet_enable_advanced_audio_settings: false
-jitsi_meet_enable_audio_translation: false
+jitsi_meet_enable_audio_translation: true
 jitsi_meet_enable_calendar: false
 jitsi_meet_enable_colibri_websockets: false
 jitsi_meet_enable_conference_request_http: false

--- a/ansible/roles/jitsi-meet/templates/config.js.j2
+++ b/ansible/roles/jitsi-meet/templates/config.js.j2
@@ -190,7 +190,9 @@ var config = {
     },
 {% if jitsi_meet_enable_audio_translation %}
     audioTranslation: {
-        enabled: true
+        enabled: true,
+        duckedVolume: {{ jitsi_meet_audio_translation_ducked_volume }},
+        enableSendingChangeEvents: true
     },
 {% endif %}
 {% if jitsi_meet_talk_while_muted_enabled %}


### PR DESCRIPTION
## Summary

Emits the two new `config.audioTranslation` sub-keys and turns the feature on by default.

- `duckedVolume` — volume (0..1) the original audio of a speaker is ducked to while its translation plays. Tunable via the new `jitsi_meet_audio_translation_ducked_volume` var, default `0.15` (the client-side default). Ignored on iOS, where the client mutes the original instead because the element volume cannot be lowered there.
- `enableSendingChangeEvents` — hardcoded `true`. Drives the per-participant "receiving translated audio" indicator.
- `jitsi_meet_enable_audio_translation` default flips `false` -> `true`, so every ansible-provisioned deployment gets audio translation.

The rendered block is now:

```js
audioTranslation: {
    enabled: true,
    duckedVolume: 0.15,
    enableSendingChangeEvents: true
},
```

### Notes

- The client's own `config.js` comment marks `enableSendingChangeEvents` as off-by-default "until the bridge emits stop notifications as well as start ones". Enabling it here is deliberate; if the indicator latches on without clearing, the mitigation is to revert this key rather than disable audio translation.
- Ansible role defaults are not visible to the Nomad web path — `yamltoenv` only sources `infra-customizations-private/config/vars.yml` and `sites/<site>/vars.yml`. The companion customizations PR sets the flag globally so Nomad-provisioned web picks it up too.
- `jitsi_meet_audio_translation_ducked_volume: 0.15` parses as a YAML `!!float`, and `yamltoenv` exports only `!!int` / `!!bool` / `!!str`. A site wishing to override the ducking level on the **Nomad** path must quote it (`jitsi_meet_audio_translation_ducked_volume: "0.2"`). On the ansible path the bare float works.

## Companion changes

- infra-provisioning: https://github.com/jitsi/infra-provisioning/pull/1161
- infra-customizations-private: https://github.com/jitsi/infra-customizations-private/pull/1090
- docker-jitsi-meet (independent): https://github.com/jitsi/docker-jitsi-meet/pull/2315

## Test plan

- `ansible/roles/jitsi-meet/defaults/main.yml` — confirm `jitsi_meet_enable_audio_translation` is `true` and `jitsi_meet_audio_translation_ducked_volume` is `0.15`; `yq` parses the file.
- `ansible/roles/jitsi-meet/templates/config.js.j2` — render for any site and confirm the `audioTranslation` block contains all three keys, and that setting `jitsi_meet_enable_audio_translation: false` omits the block entirely.
- Override `jitsi_meet_audio_translation_ducked_volume: 0.3` at a site and confirm it lands in the rendered `config.js`.
