### PR TITLE
Flip jvb_keep_alive_strategy and jvb_send_to_last_received_from_address defaults

### DIFF
--- a/ansible/roles/jitsi-videobridge/defaults/main.yml
+++ b/ansible/roles/jitsi-videobridge/defaults/main.yml
@@ -75,7 +75,7 @@ jvb_installed_package: "{{ jitsi_videobridge_deb_pkg_name }}"
 jvb_internal_muc_prefix: "{{ internal_muc_prefix | default('internal.auth') }}"
 # "sync" or "async". Async mode is currently unsafe for the bridge!
 jvb_iq_handler_mode: "sync"
-jvb_keep_alive_strategy: "selected_only"
+jvb_keep_alive_strategy: "all_succeeded"
 jvb_last_n_limits: 25
 jvb_load_threshold: "{{ jvb_load_threshold_by_shape[jvb_shape] if jvb_shape in jvb_load_threshold_by_shape else jvb_load_threshold_by_shape['default'] }}"
 jvb_load_threshold_by_shape:
@@ -188,7 +188,7 @@ jvb_rest_ssl_certificate_key: |
 jvb_rest_ssl_certificate_key_filename: "jvb_rest.service.consul.key"
 jvb_rest_ssl_dest_dir: /etc/nginx/ssl
 jvb_route_loudest_only: true
-jvb_send_to_last_received_from_address: false
+jvb_send_to_last_received_from_address: true
 jvb_server_prefix: "{{ ansible_hostname.split('.')[0] }}"
 jvb_server_id: "jvb-{{ ansible_default_ipv4.address | regex_replace('^(?P<g1>\\d+).(?P<g2>\\d+).(?P<g3>\\d+).(?P<g4>\\d+)$', '\\g<g2>-\\g<g3>-\\g<g4>') }}"
 jvb_service_name: "jitsi-videobridge2"


### PR DESCRIPTION
Changes defaults:
- jvb_keep_alive_strategy: selected_only -> all_succeeded
- jvb_send_to_last_received_from_address: false -> true

These match the value already set for meet-jit-si, prod-8x8, beta-meet-jit-si and stage-8x8 via per-environment overrides.

No functional change: a matching branch in jitsi/infra-customizations-private removes those now-redundant overrides, and adds an explicit override of the old default for jitsi-net, lonely and torture-test (which run JVB but did not previously override these vars, so they would otherwise silently pick up the new default).
