### PR TITLE
fix(jicofo): use the current package of JitsiMeetConferenceImpl in logging.properties

### DIFF
--- a/ansible/roles/jicofo/templates/logging.properties.j2
+++ b/ansible/roles/jicofo/templates/logging.properties.j2
@@ -13,7 +13,7 @@ org.jitsi.utils.logging2.JitsiLogFormatter.programname=Jicofo
 
 
 .level=INFO
-org.jitsi.jicofo.JitsiMeetConferenceImpl.level=FINE
+org.jitsi.jicofo.conference.JitsiMeetConferenceImpl.level=FINE
 {% if jicofo_enable_ssrc_logs %}
 org.jitsi.protocol.xmpp.AbstractOperationSetJingle.level=FINE
 {% endif %}


### PR DESCRIPTION
`org.jitsi.jicofo.JitsiMeetConferenceImpl.level=FINE` in the jicofo logging template targets a class path that no longer exists: the class moved to `org.jitsi.jicofo.conference` with the conference package refactoring. The setting therefore has no effect, and jicofo emits nothing at FINE for conferences (confirmed on a stage shard running jicofo 1.0-1202: zero FINE lines in `jicofo.log`; the jar has `org/jitsi/jicofo/conference/JitsiMeetConferenceImpl.class`).

This updates the logger name to the current package.

Not changed here: the `jicofo_enable_ssrc_logs` block sets a level for `org.jitsi.protocol.xmpp.AbstractOperationSetJingle`, which also no longer exists in current jicofo. It is off by default, so it is inert; it can be dropped or repointed separately if SSRC logging is still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
