### PR TITLE
feat(jitsi-meet): add jitsi_meet_disable_av1_decode_for_ff flag

### DIFF
--- a/ansible/roles/jitsi-meet/defaults/main.yml
+++ b/ansible/roles/jitsi-meet/defaults/main.yml
@@ -123,6 +123,7 @@ jitsi_meet_cors_avatar_urls: false
 jitsi_meet_deb_pkg_name: "jitsi-meet-web"
 jitsi_meet_deb_pkg_version: "*"
 jitsi_meet_default_remote_displayname: false
+jitsi_meet_disable_av1_decode_for_ff: true
 jitsi_meet_disable_firefox_p2p: false
 jitsi_meet_disable_iframe_api: false
 jitsi_meet_disable_reactions: false

--- a/ansible/roles/jitsi-meet/templates/config.js.j2
+++ b/ansible/roles/jitsi-meet/templates/config.js.j2
@@ -598,6 +598,9 @@ whiteboard: {
     },
     testing: {
         enableCodecSelectionAPI: true,
+    {% if jitsi_meet_disable_av1_decode_for_ff %}
+        disableAV1DecodeForFF: true,
+    {% endif %}
     {% if jitsi_meet_mobile_xmpp_ws_threshold %}
         mobileXmppWsThreshold: {{ jitsi_meet_mobile_xmpp_ws_threshold }},
     {% endif %}


### PR DESCRIPTION
## Summary

Adds `jitsi_meet_disable_av1_decode_for_ff`, which renders `config.testing.disableAV1DecodeForFF` into the site config.

Firefox assembles the frames of an AV1 stream that carries spatial layers but never emits them from the jitter buffer, so video from an endpoint sending AV1 SVC never decodes: https://bugzilla.mozilla.org/show_bug.cgi?id=2071030

The client-side flag removes AV1 from the codec list on Firefox, so it is neither advertised nor sent to it and remote endpoints fall back to VP9.

**The default is `true`**, i.e. on for every site, since the Firefox limitation affects all deployments. Set the var to `false` on a site to keep AV1 enabled there.

## Companion changes

- lib-jitsi-meet: https://github.com/jitsi/lib-jitsi-meet/pull/3108 (implements the flag)
- jitsi-meet: https://github.com/jitsi/jitsi-meet/pull/17813 (config docs and typing)
- infra-provisioning: https://github.com/jitsi/infra-provisioning/pull/1177 (same flag for the Nomad path)
- docker-jitsi-meet: https://github.com/jitsi/docker-jitsi-meet/pull/2322 (`DISABLE_AV1_DECODE_FOR_FF`)

No effect until the lib-jitsi-meet change is released; the client ignores the unknown key until then.

## Test plan

- `defaults/main.yml`: the var defaults to `true`.
- `config.js.j2`: rendered `config.js` contains `disableAV1DecodeForFF: true` inside the existing `testing` block; setting the var to `false` omits the line. The key is added to the existing `testing` object rather than a second one, so it cannot be shadowed by a duplicate.
