### PR TITLE
fix: Update consul apt key ID to match HashiCorp's rotated signing key

### DIFF
--- a/ansible/roles/consul-install/tasks/main.yml
+++ b/ansible/roles/consul-install/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Install consul apt key
   ansible.builtin.apt_key:
     url: "{{ consul_apt_key }}"
-    id: AA16FCBCA621E701
+    id: FC9CA96ACA026560
     state: present
     validate_certs: false
 


### PR DESCRIPTION
## Summary
- HashiCorp rotated their APT signing key; the `id` pinned in `consul-install`'s apt_key task (`AA16FCBCA621E701`) no longer matches the key served at `apt.releases.hashicorp.com/gpg` (now `FC9CA96ACA026560`, verified by downloading and inspecting the key with gpg).
- Because the old key was already trusted on the base image, the `apt_key` task silently no-ops instead of fetching the new key, so `apt-get update` later fails signature verification (`NO_PUBKEY`) for the HashiCorp apt repo.
- This broke the Signal (and any other consul-installing) Oracle image build pipeline with exit code 2.
- Same class of fix has been applied twice before in this role's history for prior HashiCorp key rotations.

## Test plan
- [ ] Re-run the Signal image build pipeline (`build-image-oracle`) and confirm the `consul-install : Install consul apt repo` task succeeds and the image builds to completion.