### PR TITLE
fix(jibri): write the ASAP signing key as traditional RSA PEM

### DIFF
--- a/ansible/roles/jibri-java/tasks/configure.yml
+++ b/ansible/roles/jibri-java/tasks/configure.yml
@@ -102,11 +102,43 @@
     - configure_jibri is defined
     - (jibri_config_hosts.keys()|length == 0)
 
-- name: Copy jibri ASAP JWT signing key
-  ansible.builtin.copy:
-    dest: "{{ jibri_asap_key_path }}"
+# Jibri parses the signing key with BouncyCastle's PEMParser and casts the
+# result to PEMKeyPair, which is only what a traditional PKCS#1
+# "-----BEGIN RSA PRIVATE KEY-----" block parses to. Recent BouncyCastle returns
+# PrivateKeyInfo for PKCS#8 "-----BEGIN PRIVATE KEY-----" keys, the cast throws
+# ClassCastException, and jibri silently boots with JWT/ASAP auth disabled.
+# Re-encode whatever format the secret is in to traditional PEM on the way out.
+# OpenSSL 3 (jammy) emits PKCS#8 unless told -traditional; OpenSSL 1.1 (focal)
+# emits traditional PEM by default and does not know the flag.
+- name: Write jibri ASAP JWT signing key as traditional RSA PEM
+  ansible.builtin.shell: |
+    set -eo pipefail
+    umask 077
+    tmp="$(mktemp {{ jibri_asap_key_path }}.XXXXXX)"
+    trap 'rm -f "$tmp"' EXIT
+    traditional=""
+    if openssl rsa -help 2>&1 | grep -q -- '-traditional'; then
+      traditional="-traditional"
+    fi
+    openssl rsa $traditional -out "$tmp"
+    grep -q -- '-----BEGIN RSA PRIVATE KEY-----' "$tmp"
+    if cmp -s "$tmp" "{{ jibri_asap_key_path }}"; then
+      echo unchanged
+    else
+      mv "$tmp" "{{ jibri_asap_key_path }}"
+      echo changed
+    fi
+  args:
+    stdin: "{{ asap_key['key'] }}"
+    executable: /bin/bash
+  register: jibri_asap_key_result
+  changed_when: "'changed' in jibri_asap_key_result.stdout"
+  no_log: true
+
+- name: Set jibri ASAP JWT signing key permissions
+  ansible.builtin.file:
+    path: "{{ jibri_asap_key_path }}"
     mode: 0640
-    content: "{{ asap_key['key'] }}"
     owner: "{{ jibri_username }}"
 
 - name: Remove jibri legacy config file


### PR DESCRIPTION
## Problem

Recent jibri images ship a newer BouncyCastle. Its `PEMParser.readObject()` now returns `PrivateKeyInfo` for PKCS#8 keys (`-----BEGIN PRIVATE KEY-----`), but jibri's `JwtInfo.fromConfig` blind-casts the result to `PEMKeyPair`, the type it gets for traditional PKCS#1 keys (`-----BEGIN RSA PRIVATE KEY-----`). With a PKCS#8 `asap.key` every boot logs:

```
JwtInfo$Companion.fromConfig#50: Unable to create JwtInfo:
java.lang.ClassCastException: class org.bouncycastle.asn1.pkcs.PrivateKeyInfo cannot be cast to class org.bouncycastle.openssl.PEMKeyPair
```

The process stays up and reports healthy, but JWT/ASAP auth is silently disabled.

## Fix

The `jibri-java` role no longer copies the secret verbatim to `/etc/jitsi/jibri/asap.key`. It now feeds the key to `openssl rsa` over stdin and writes the traditional PKCS#1 encoding, which both old and new BouncyCastle parse as `PEMKeyPair`.

- Accepts either PKCS#8 or PKCS#1 input, so no secret needs to change.
- Detects whether the local OpenSSL supports `-traditional` (OpenSSL 3 / jammy) or already emits PKCS#1 by default and rejects the flag (OpenSSL 1.1 / focal).
- Verifies the output header and fails the play if conversion did not produce an RSA PRIVATE KEY block.
- Writes through a `mktemp` file with `umask 077`, then a separate `file` task applies the existing `0640` / `jibri` ownership.
- Idempotent: reports `changed` only when the key on disk differs.
- `no_log` on the conversion task so the key never lands in Ansible output.

The durable fix is for jibri itself to handle both `PEMKeyPair` and `PrivateKeyInfo`; this keeps the infrastructure working with the current image in the meantime.

## Testing

Ran the shell snippet locally (OpenSSL 3): PKCS#8 in produces a PKCS#1 key with the same modulus, a second run reports unchanged, PKCS#1 input of the same key also reports unchanged, garbage input exits non-zero, no temp files are left behind. `ansible-lint` passes with the production profile.
