### PR TITLE
fix(jibri): validate consul-template renders and stop reload races from killing the runner

### DIFF
--- a/ansible/configure-jibri-java-local-oracle.yml
+++ b/ansible/configure-jibri-java-local-oracle.yml
@@ -31,13 +31,19 @@
     consul_template_template_files:
       - src: roles/jibri-java/files/xmpp.conf.template
     consul_template_templates:
+      # rendered to a candidate file; reconfigure-jibri-wrapper.sh validates it and
+      # promotes it to /etc/jitsi/jibri/xmpp.conf before reloading jibri
       - name: "xmpp.conf.template"
-        dest: "/etc/jitsi/jibri/xmpp.conf"
+        dest: "/etc/jitsi/jibri/xmpp.conf.candidate"
         cmd: "/usr/local/bin/reconfigure-jibri-wrapper.sh"
         user: "root"
         group: "{{ 1000 if jibri_docker_compose_flag else 'jitsi' }}" # uses 1000 for jitsi group in docker image
         perms: 0640
         backup: false
+        # debounce: shard registrations flap during releases, coalesce bursts into one render
+        wait: "{{ jibri_consul_template_wait | default('15s:60s') }}"
+        # the wrapper may wait for jibri to finish (re)starting before reloading it
+        command_timeout: "{{ jibri_consul_template_command_timeout | default('300s') }}"
 
   pre_tasks:
     - name: Get instance's details

--- a/ansible/roles/consul-template/README.md
+++ b/ansible/roles/consul-template/README.md
@@ -34,7 +34,7 @@ consul_template_wait: <undefined>
 consul_template_template_files: # Copies your templates
     - {src: "template.ctmpl"}
 consul_template_templates: # Defines templates in configuration
-    - {name: "template.ctmpl", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true, wait: "2s"}
+    - {name: "template.ctmpl", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true, wait: "2s:10s", command_timeout: "60s"}
 consul_template_template_templates: # Defines j2 versions of templates to be rendered as consul-template templates
     - {name: "template.ctmpl.j2", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true}
 consul_template_manage_user: false

--- a/ansible/roles/consul-template/templates/consul-template.cfg.j2
+++ b/ansible/roles/consul-template/templates/consul-template.cfg.j2
@@ -22,7 +22,8 @@ template {
   {% if template.cmd is defined %}command = "{{ template.cmd }}"{% endif %}
   {% if template.perms is defined %}perms = {{ template.perms }}{% endif %}
   {% if template.backup is defined %}backup = {{ template.backup|lower }}{% endif %}
-  {% if template.wait is defined %}wait = {{ template.wait|lower }}{% endif %}
+  {% if template.wait is defined %}wait = "{{ template.wait }}"{% endif %}
+  {% if template.command_timeout is defined %}command_timeout = "{{ template.command_timeout }}"{% endif %}
 }{% endfor %}
 {% endif -%}
 {% endif -%}

--- a/ansible/roles/jibri-java/files/consul-passing-hosts.py
+++ b/ansible/roles/jibri-java/files/consul-passing-hosts.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Print the XMPP "host:port" entries that consul currently considers healthy,
+one per line, sorted. This mirrors what the jibri xmpp.conf.template renders:
+the union of the passing "signal" and "all" services, using the
+prosody_client_port service meta when present and 5222 otherwise.
+
+Used by reconfigure-jibri-wrapper.sh to decide whether a rendered config that
+drops hosts reflects a real shard removal or a transient consul view.
+
+Usage:
+    consul-passing-hosts.py [--consul URL] [--service NAME ...] [--timeout SECONDS]
+
+Exit codes:
+    0  success (an empty list is still a success)
+    1  consul could not be queried
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_CONSUL = "http://127.0.0.1:8500"
+DEFAULT_SERVICES = ["signal", "all"]
+DEFAULT_PORT = "5222"
+
+
+def passing_hosts(consul_url, services, timeout):
+    base = consul_url.rstrip("/")
+    hosts = set()
+    for svc in services:
+        url = "%s/v1/health/service/%s?passing" % (base, svc)
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            for entry in json.load(resp):
+                service = entry.get("Service") or {}
+                addr = service.get("Address") or (entry.get("Node") or {}).get("Address")
+                if not addr:
+                    continue
+                port = (service.get("Meta") or {}).get("prosody_client_port") or DEFAULT_PORT
+                hosts.add("%s:%s" % (addr, port))
+    return sorted(hosts)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--consul", default=DEFAULT_CONSUL, help="consul HTTP address (default %(default)s)")
+    parser.add_argument(
+        "--service",
+        action="append",
+        dest="services",
+        help="service name to include; repeatable (default: %s)" % " ".join(DEFAULT_SERVICES),
+    )
+    parser.add_argument("--timeout", type=float, default=5.0, help="per-request timeout in seconds (default %(default)s)")
+    args = parser.parse_args()
+
+    try:
+        hosts = passing_hosts(args.consul, args.services or DEFAULT_SERVICES, args.timeout)
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        print("consul-passing-hosts: failed to query %s: %s" % (args.consul, exc), file=sys.stderr)
+        return 1
+
+    for host in hosts:
+        print(host)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ansible/roles/jibri-java/files/reconfigure-jibri-wrapper.sh
+++ b/ansible/roles/jibri-java/files/reconfigure-jibri-wrapper.sh
@@ -1,39 +1,296 @@
 #!/bin/bash
+#
+# consul-template command hook for the jibri xmpp.conf template.
+#
+# consul-template renders the template to a *candidate* file. This script
+# validates the candidate, decides whether it is safe to promote it to the live
+# xmpp.conf, and then asks jibri to reload (which makes jibri exit when idle so
+# systemd restarts it with the new config).
+#
+# Design notes (see git history for the incident that motivated this):
+#   * jibri has no config-file watcher of its own; the only thing that restarts
+#     it on a config change is this script calling `service jibri reload`.
+#   * jibri takes ~10s+ to boot (chrome warm-up in ExecStartPre). A reload issued
+#     while the unit is still activating fails, and if this script exits non-zero
+#     consul-template tears down its whole runner. So we wait for jibri to be
+#     active, retry the reload with backoff, and *always* exit 0. Failures are
+#     reported via statsd metrics and the log file instead.
+#   * A render that drops shards is treated as suspect: the shard registration
+#     in consul flaps during releases, and a render taken from that partial view
+#     would disconnect jibri from a healthy shard. If shards were removed we wait
+#     a short settle period and re-check consul; if any removed shard is healthy
+#     again the candidate is rejected and consul-template's next render (which
+#     will contain the shard again) gets applied instead.
+#
+# Tunables (environment):
+#   XMPP_CONF_FILE                live config        (default /etc/jitsi/jibri/xmpp.conf)
+#   XMPP_CONF_CANDIDATE_FILE      rendered candidate (default ${XMPP_CONF_FILE}.candidate)
+#   JIBRI_CONF_FILE               jibri.conf, used to find the internal API port
+#   CONSUL_HTTP_ADDR              local consul agent (default http://127.0.0.1:8500)
+#   JIBRI_SHRINK_SETTLE_SECONDS   wait before re-checking consul on a shrink (default 20)
+#   JIBRI_ACTIVE_TIMEOUT_SECONDS  max wait for jibri.service to become active (default 120)
+#   JIBRI_RELOAD_ATTEMPTS         reload attempts (default 3, backoff 5s/10s/20s)
+#   JIBRI_LOCK_WAIT_SECONDS       max wait for the wrapper lock (default 120)
 
 function timestamp() {
   date --utc +%Y-%m-%d_%H:%M:%S.Z
 }
 
 function log_msg() {
-  echo "$(timestamp) [$$] jibri-wrapper: $1" | tee -a $TEMPLATE_LOGFILE
+  echo "$(timestamp) [$$] jibri-wrapper: $1" | tee -a "$TEMPLATE_LOGFILE"
+}
+
+function metric() {
+  # $1 metric name (suffix of jitsi.config.jibri.), $2 value
+  echo -n "jitsi.config.jibri.$1:$2|c" | nc -4u -w1 localhost 8125
+}
+
+# extract the set of "host:port" entries from all xmpp-server-hosts lines in a file
+function hosts_in() {
+  [ -f "$1" ] || return 0
+  grep 'xmpp-server-hosts' "$1" | grep -oE '"[^"]+"' | tr -d '"' | sort -u
+}
+
+# set difference: lines in $1 not in $2 (both newline separated strings)
+function set_diff() {
+  comm -23 <(echo "$1" | sed '/^$/d' | sort -u) <(echo "$2" | sed '/^$/d' | sort -u)
+}
+
+function count_lines() {
+  echo "$1" | sed '/^$/d' | wc -l | tr -d ' '
+}
+
+# Ask the local consul agent for the currently *passing* signal/all services and
+# print them as "host:port" lines, mirroring what xmpp.conf.template renders.
+# Prints nothing and returns non-zero if consul cannot be queried.
+function consul_passing_hosts() {
+  local out rc
+  out=$(python3 - "$CONSUL_HTTP_ADDR" <<'PYEOF'
+import json, sys, urllib.request
+base = sys.argv[1].rstrip('/')
+hosts = set()
+for svc in ("signal", "all"):
+    with urllib.request.urlopen("%s/v1/health/service/%s?passing" % (base, svc), timeout=5) as r:
+        for entry in json.load(r):
+            s = entry.get("Service", {})
+            addr = s.get("Address") or entry.get("Node", {}).get("Address")
+            if not addr:
+                continue
+            port = (s.get("Meta") or {}).get("prosody_client_port") or "5222"
+            hosts.add("%s:%s" % (addr, port))
+print("\n".join(sorted(hosts)))
+PYEOF
+  )
+  rc=$?
+  echo "$out"
+  return $rc
+}
+
+function jibri_internal_api_port() {
+  local port=""
+  if command -v hocon >/dev/null 2>&1; then
+    port=$(hocon -f "$JIBRI_CONF_FILE" get jibri.api.http.internal-api-port 2>/dev/null || true)
+  fi
+  if [ -z "$port" ]; then
+    port=$(grep -oE 'internal-api-port[[:space:]]*=[[:space:]]*[0-9]+' "$JIBRI_CONF_FILE" 2>/dev/null | grep -oE '[0-9]+$' | head -1)
+  fi
+  [ -z "$port" ] && port=3333
+  echo "$port"
+}
+
+# Wait until jibri.service is 'active' and its internal HTTP API answers.
+# Returns 0 when ready, 1 when jibri is not running at all (inactive/failed),
+# 2 on timeout.
+function wait_for_jibri_ready() {
+  local deadline=$(( $(date +%s) + JIBRI_ACTIVE_TIMEOUT_SECONDS ))
+  local port state
+  port=$(jibri_internal_api_port)
+  while true; do
+    state=$(systemctl is-active jibri 2>/dev/null)
+    case "$state" in
+      active)
+        if curl -s -o /dev/null --max-time 3 "http://127.0.0.1:${port}/"; then
+          return 0
+        fi
+        ;;
+      inactive|failed)
+        # do not wait for something that is not coming back on its own
+        return 1
+        ;;
+    esac
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      log_msg "timed out waiting for jibri.service to be ready (state=${state:-unknown})"
+      return 2
+    fi
+    sleep 2
+  done
 }
 
 [ -z "$TEMPLATE_LOGDIR" ] && TEMPLATE_LOGDIR="/var/log/jitsi/jibri-shards"
-
-[ -d "$TEMPLATE_LOGDIR" ] || mkdir -p $TEMPLATE_LOGDIR
+[ -d "$TEMPLATE_LOGDIR" ] || mkdir -p "$TEMPLATE_LOGDIR"
 [ -z "$TEMPLATE_LOGFILE" ] && TEMPLATE_LOGFILE="$TEMPLATE_LOGDIR/jibri-reconfigure.log"
 [ -z "$XMPP_CONF_FILE" ] && XMPP_CONF_FILE="/etc/jitsi/jibri/xmpp.conf"
+[ -z "$XMPP_CONF_CANDIDATE_FILE" ] && XMPP_CONF_CANDIDATE_FILE="${XMPP_CONF_FILE}.candidate"
+[ -z "$JIBRI_CONF_FILE" ] && JIBRI_CONF_FILE="/etc/jitsi/jibri/jibri.conf"
+[ -z "$CONSUL_HTTP_ADDR" ] && CONSUL_HTTP_ADDR="http://127.0.0.1:8500"
+[ -z "$JIBRI_SHRINK_SETTLE_SECONDS" ] && JIBRI_SHRINK_SETTLE_SECONDS=20
+[ -z "$JIBRI_ACTIVE_TIMEOUT_SECONDS" ] && JIBRI_ACTIVE_TIMEOUT_SECONDS=120
+[ -z "$JIBRI_RELOAD_ATTEMPTS" ] && JIBRI_RELOAD_ATTEMPTS=3
+[ -z "$JIBRI_LOCK_WAIT_SECONDS" ] && JIBRI_LOCK_WAIT_SECONDS=120
+
+readonly LOCK_FILE="/var/lock/reconfigure-jibri-wrapper.lock"
+readonly LOCK_FD=200
 
 log_msg "starting"
-cp $XMPP_CONF_FILE $TEMPLATE_LOGDIR/xmpp.conf.$(date --utc +%Y-%m-%d_%H:%M:%S.Z)
+# always emit a 0 so the counters exist even on quiet hosts
+metric "shards_update" 0
+metric "shards_update_failed" 0
+metric "shards_candidate_rejected" 0
 
-/usr/sbin/service jibri reload
-RET=$?
-
-if [ $RET -gt 0 ]; then
-    log_msg "update failed"
-    echo -n "jitsi.config.jibri.shards_update_update_failed:1|c" | nc -4u -w1 localhost 8125
-else
-    log_msg "update successful"
-    echo -n "jitsi.config.jibri.shards_update_failed:0|c" | nc -4u -w1 localhost 8125
+# ---------------------------------------------------------------------------
+# serialize: never let two invocations race each other
+# ---------------------------------------------------------------------------
+eval "exec $LOCK_FD>$LOCK_FILE"
+if ! flock -w "$JIBRI_LOCK_WAIT_SECONDS" $LOCK_FD; then
+  log_msg "could not acquire lock within ${JIBRI_LOCK_WAIT_SECONDS}s, another reconfigure is still running; skipping"
+  metric "shards_update_lock_timeout" 1
+  exit 0
 fi
 
-echo -n "jitsi.config.jibri.shards_update:1|c" | nc -4u -w1 localhost 8125
+CONFIG_TIMESTAMP=$(timestamp)
 
+# ---------------------------------------------------------------------------
+# validate the candidate
+# ---------------------------------------------------------------------------
+if [ ! -s "$XMPP_CONF_CANDIDATE_FILE" ]; then
+  log_msg "candidate $XMPP_CONF_CANDIDATE_FILE is missing or empty; rejecting"
+  metric "shards_candidate_rejected" 1
+  metric "shards_candidate_empty" 1
+  exit 0
+fi
+
+cp "$XMPP_CONF_CANDIDATE_FILE" "$TEMPLATE_LOGDIR/xmpp.conf.candidate.$CONFIG_TIMESTAMP"
+
+if ! grep -q 'jibri.api.xmpp.environments' "$XMPP_CONF_CANDIDATE_FILE"; then
+  log_msg "candidate does not look like a jibri xmpp config; rejecting"
+  metric "shards_candidate_rejected" 1
+  metric "shards_candidate_invalid" 1
+  exit 0
+fi
+
+NEW_HOSTS=$(hosts_in "$XMPP_CONF_CANDIDATE_FILE")
+LIVE_HOSTS=$(hosts_in "$XMPP_CONF_FILE")
+NEW_COUNT=$(count_lines "$NEW_HOSTS")
+LIVE_COUNT=$(count_lines "$LIVE_HOSTS")
+metric "shards_candidate_hosts" "$NEW_COUNT"
+
+if [ "$NEW_COUNT" -eq 0 ]; then
+  log_msg "candidate contains no xmpp-server-hosts (live has $LIVE_COUNT); rejecting"
+  metric "shards_candidate_rejected" 1
+  metric "shards_candidate_empty" 1
+  exit 0
+fi
+
+if [ -f "$XMPP_CONF_FILE" ] && cmp -s "$XMPP_CONF_CANDIDATE_FILE" "$XMPP_CONF_FILE"; then
+  log_msg "candidate is identical to live config; nothing to do"
+  metric "shards_update_noop" 1
+  exit 0
+fi
+
+REMOVED_HOSTS=$(set_diff "$LIVE_HOSTS" "$NEW_HOSTS")
+ADDED_HOSTS=$(set_diff "$NEW_HOSTS" "$LIVE_HOSTS")
+REMOVED_COUNT=$(count_lines "$REMOVED_HOSTS")
+ADDED_COUNT=$(count_lines "$ADDED_HOSTS")
+
+[ "$ADDED_COUNT" -gt 0 ] && log_msg "candidate adds $ADDED_COUNT host(s): $(echo $ADDED_HOSTS)"
+
+# ---------------------------------------------------------------------------
+# a shrink is suspect: re-check consul after a settle period
+# ---------------------------------------------------------------------------
+if [ "$REMOVED_COUNT" -gt 0 ]; then
+  log_msg "candidate removes $REMOVED_COUNT host(s): $(echo $REMOVED_HOSTS); settling ${JIBRI_SHRINK_SETTLE_SECONDS}s before re-checking consul"
+  metric "shards_shrink_detected" 1
+  sleep "$JIBRI_SHRINK_SETTLE_SECONDS"
+
+  if CONSUL_HOSTS=$(consul_passing_hosts); then
+    STILL_HEALTHY=$(comm -12 <(echo "$REMOVED_HOSTS" | sed '/^$/d' | sort -u) <(echo "$CONSUL_HOSTS" | sed '/^$/d' | sort -u))
+    STILL_HEALTHY_COUNT=$(count_lines "$STILL_HEALTHY")
+    if [ "$STILL_HEALTHY_COUNT" -gt 0 ]; then
+      log_msg "$STILL_HEALTHY_COUNT removed host(s) are passing in consul again ($(echo $STILL_HEALTHY)); render was taken from a transient view, rejecting candidate and keeping live config"
+      metric "shards_candidate_rejected" 1
+      metric "shards_shrink_transient" "$STILL_HEALTHY_COUNT"
+      exit 0
+    fi
+    log_msg "removed host(s) confirmed absent from consul; accepting shrink"
+  else
+    log_msg "could not query consul at $CONSUL_HTTP_ADDR to verify the shrink; accepting candidate as rendered"
+    metric "shards_shrink_unverified" 1
+  fi
+  metric "shards_removed" "$REMOVED_COUNT"
+fi
+[ "$ADDED_COUNT" -gt 0 ] && metric "shards_added" "$ADDED_COUNT"
+
+# ---------------------------------------------------------------------------
+# promote candidate -> live (atomically, preserving ownership/mode)
+# ---------------------------------------------------------------------------
+[ -f "$XMPP_CONF_FILE" ] && cp "$XMPP_CONF_FILE" "$TEMPLATE_LOGDIR/xmpp.conf.previous.$CONFIG_TIMESTAMP"
+TMP_LIVE="${XMPP_CONF_FILE}.tmp.$$"
+if ! cp "$XMPP_CONF_CANDIDATE_FILE" "$TMP_LIVE"; then
+  log_msg "failed to stage new live config; aborting"
+  metric "shards_update_failed" 1
+  rm -f "$TMP_LIVE"
+  exit 0
+fi
+chown --reference="$XMPP_CONF_CANDIDATE_FILE" "$TMP_LIVE" 2>/dev/null
+chmod --reference="$XMPP_CONF_CANDIDATE_FILE" "$TMP_LIVE" 2>/dev/null
+mv -f "$TMP_LIVE" "$XMPP_CONF_FILE"
+log_msg "promoted candidate to $XMPP_CONF_FILE ($LIVE_COUNT -> $NEW_COUNT hosts)"
+metric "shards_update" 1
+
+# ---------------------------------------------------------------------------
+# reload jibri, tolerating an in-flight (re)start
+# ---------------------------------------------------------------------------
+wait_for_jibri_ready
+READY_RC=$?
+if [ $READY_RC -eq 1 ]; then
+  log_msg "jibri.service is not running ($(systemctl is-active jibri 2>/dev/null)); new config will be read on next start, skipping reload"
+  metric "shards_update_reload_skipped" 1
+  exit 0
+fi
+
+RET=1
+ATTEMPT=1
+BACKOFF=5
+while [ $ATTEMPT -le "$JIBRI_RELOAD_ATTEMPTS" ]; do
+  log_msg "reloading jibri (attempt $ATTEMPT/$JIBRI_RELOAD_ATTEMPTS)"
+  /usr/sbin/service jibri reload
+  RET=$?
+  [ $RET -eq 0 ] && break
+  log_msg "jibri reload failed (rc=$RET)"
+  if [ $ATTEMPT -lt "$JIBRI_RELOAD_ATTEMPTS" ]; then
+    sleep $BACKOFF
+    BACKOFF=$(( BACKOFF * 2 ))
+    wait_for_jibri_ready
+  fi
+  ATTEMPT=$(( ATTEMPT + 1 ))
+done
+
+if [ $RET -gt 0 ]; then
+  log_msg "update failed: jibri did not accept the reload after $JIBRI_RELOAD_ATTEMPTS attempts"
+  metric "shards_update_failed" 1
+  # legacy metric name, kept so existing dashboards/alerts keep working
+  metric "shards_update_update_failed" 1
+else
+  log_msg "update successful"
+fi
+
+# give jibri time to exit (when idle) so a follow-up render finds the unit
+# restarting rather than about to restart
 log_msg "sleep 10 after reload"
 sleep 10
 
 log_msg "complete"
 
-
-exit $RET
+# Never propagate a failure to consul-template: a non-zero exit here kills the
+# whole consul-template runner, which is far worse than one missed reload.
+exit 0

--- a/ansible/roles/jibri-java/files/reconfigure-jibri-wrapper.sh
+++ b/ansible/roles/jibri-java/files/reconfigure-jibri-wrapper.sh
@@ -27,6 +27,8 @@
 #   XMPP_CONF_CANDIDATE_FILE      rendered candidate (default ${XMPP_CONF_FILE}.candidate)
 #   JIBRI_CONF_FILE               jibri.conf, used to find the internal API port
 #   CONSUL_HTTP_ADDR              local consul agent (default http://127.0.0.1:8500)
+#   CONSUL_PASSING_HOSTS_SCRIPT   helper that lists passing signal/all hosts from consul
+#                                 (default /usr/local/bin/consul-passing-hosts.py)
 #   JIBRI_SHRINK_SETTLE_SECONDS   wait before re-checking consul on a shrink (default 20)
 #   JIBRI_ACTIVE_TIMEOUT_SECONDS  max wait for jibri.service to become active (default 120)
 #   JIBRI_RELOAD_ATTEMPTS         reload attempts (default 3, backoff 5s/10s/20s)
@@ -64,26 +66,11 @@ function count_lines() {
 # print them as "host:port" lines, mirroring what xmpp.conf.template renders.
 # Prints nothing and returns non-zero if consul cannot be queried.
 function consul_passing_hosts() {
-  local out rc
-  out=$(python3 - "$CONSUL_HTTP_ADDR" <<'PYEOF'
-import json, sys, urllib.request
-base = sys.argv[1].rstrip('/')
-hosts = set()
-for svc in ("signal", "all"):
-    with urllib.request.urlopen("%s/v1/health/service/%s?passing" % (base, svc), timeout=5) as r:
-        for entry in json.load(r):
-            s = entry.get("Service", {})
-            addr = s.get("Address") or entry.get("Node", {}).get("Address")
-            if not addr:
-                continue
-            port = (s.get("Meta") or {}).get("prosody_client_port") or "5222"
-            hosts.add("%s:%s" % (addr, port))
-print("\n".join(sorted(hosts)))
-PYEOF
-  )
-  rc=$?
-  echo "$out"
-  return $rc
+  if [ ! -x "$CONSUL_PASSING_HOSTS_SCRIPT" ]; then
+    log_msg "$CONSUL_PASSING_HOSTS_SCRIPT is missing or not executable"
+    return 1
+  fi
+  "$CONSUL_PASSING_HOSTS_SCRIPT" --consul "$CONSUL_HTTP_ADDR" 2>> "$TEMPLATE_LOGFILE"
 }
 
 function jibri_internal_api_port() {
@@ -133,6 +120,7 @@ function wait_for_jibri_ready() {
 [ -z "$XMPP_CONF_CANDIDATE_FILE" ] && XMPP_CONF_CANDIDATE_FILE="${XMPP_CONF_FILE}.candidate"
 [ -z "$JIBRI_CONF_FILE" ] && JIBRI_CONF_FILE="/etc/jitsi/jibri/jibri.conf"
 [ -z "$CONSUL_HTTP_ADDR" ] && CONSUL_HTTP_ADDR="http://127.0.0.1:8500"
+[ -z "$CONSUL_PASSING_HOSTS_SCRIPT" ] && CONSUL_PASSING_HOSTS_SCRIPT="/usr/local/bin/consul-passing-hosts.py"
 [ -z "$JIBRI_SHRINK_SETTLE_SECONDS" ] && JIBRI_SHRINK_SETTLE_SECONDS=20
 [ -z "$JIBRI_ACTIVE_TIMEOUT_SECONDS" ] && JIBRI_ACTIVE_TIMEOUT_SECONDS=120
 [ -z "$JIBRI_RELOAD_ATTEMPTS" ] && JIBRI_RELOAD_ATTEMPTS=3

--- a/ansible/roles/jibri-java/tasks/configure.yml
+++ b/ansible/roles/jibri-java/tasks/configure.yml
@@ -235,6 +235,13 @@
     mode: 0755
     owner: root
 
+- name: Upload consul passing-hosts helper for the jibri configurator
+  ansible.builtin.copy:
+    dest: "/usr/local/bin/consul-passing-hosts.py"
+    src: "consul-passing-hosts.py"
+    mode: 0755
+    owner: root
+
   # Run the metric reporting script regularly
 - name: Jibri status script cron
   ansible.builtin.cron:

--- a/ansible/roles/jibri-java/tasks/install.yml
+++ b/ansible/roles/jibri-java/tasks/install.yml
@@ -83,6 +83,13 @@
     mode: 0755
     owner: root
 
+- name: Upload consul passing-hosts helper for the jibri configurator
+  ansible.builtin.copy:
+    dest: "/usr/local/bin/consul-passing-hosts.py"
+    src: "consul-passing-hosts.py"
+    mode: 0755
+    owner: root
+
 # script to handle stats to cloudwatch
 - name: Copy status cloudwatch script aws
   ansible.builtin.copy:


### PR DESCRIPTION
## Problem

During a release, consul-template re-rendered `/etc/jitsi/jibri/xmpp.conf` three times in ~31 seconds on every jibri. Each render ran `reconfigure-jibri-wrapper.sh`, which does `service jibri reload`. That reload hits jibri's `notifyConfigChanged` API, and jibri exits when idle so systemd restarts it. Jibri has no config-file watcher of its own; the "self restart" seen in the logs was our reload.

Jibri takes 10s+ to come up (chrome warm-up in `ExecStartPre`), so the third reload landed while the unit was still activating:

```
Job for jibri.service failed. See "systemctl status jibri.service" ...
[ERR] (cli) 1 error occurred: failed to execute command "/usr/local/bin/reconfigure-jibri-wrapper.sh"
      ... child: command exited with a non-zero exit status
consul-template v0.31.0 - (runner) starting / creating new runner
```

The wrapper exited non-zero and consul-template tore down its whole runner. Worse, that third render had been taken from a transient consul view (shard registrations flap while a shard is being reconfigured) and was missing a healthy shard, so the jibris booted with no XMPP connection to it and jicofo on that shard saw no jibris at all.

## Changes

**Render to a candidate, validate, then promote** (same pattern the JVB and jigasi wrappers already use)
- `xmpp.conf.template` now renders to `/etc/jitsi/jibri/xmpp.conf.candidate`.
- The wrapper rejects an empty or non-jibri candidate, and is a no-op if the candidate is byte-identical to the live config.
- If the candidate **removes** hosts, the wrapper waits a settle period (20s) and re-queries the passing `signal`/`all` services from the local consul agent via a new standalone helper, `/usr/local/bin/consul-passing-hosts.py` (prints `host:port` lines, exits 1 if consul is unreachable, in which case the wrapper fails open and applies the render). If any removed host is healthy again, the render is treated as transient and rejected; consul-template's next render (which contains the host again) gets applied instead. If the hosts are genuinely gone, the shrink is accepted.
- The candidate is promoted atomically, preserving owner/mode.

**Tolerant, serialized reload**
- `flock` so two invocations never overlap.
- Waits for `jibri.service` to be `active` and its internal HTTP API to answer before reloading. If jibri is `inactive`/`failed` (e.g. intentionally stopped for graceful shutdown) the reload is skipped; jibri reads the new file on next start.
- Retries the reload 3 times with backoff.
- **Always exits 0.** A failed reload must never kill the consul-template runner. Failures are surfaced via log and statsd instead.

**Debounce**
- Template-level `wait = "15s:60s"` so a burst of catalog changes during a release coalesces into one render. Overridable via `jibri_consul_template_wait`.
- `command_timeout = "300s"` so the wrapper has room to wait for jibri. Overridable via `jibri_consul_template_command_timeout`.

**consul-template role**
- Template-level `wait` is now emitted quoted (it is a `"min:max"` string; the old `|lower` unquoted form produced invalid HCL and was unused).
- Added `command_timeout` support to the template stanza.

## Metrics

All under `jitsi.config.jibri.` (statsd counters):

| metric | meaning |
|---|---|
| `shards_update` | candidate promoted to live |
| `shards_update_noop` | candidate identical to live |
| `shards_update_failed` | reload failed after retries (legacy `shards_update_update_failed` still emitted) |
| `shards_update_reload_skipped` | jibri not running, reload skipped |
| `shards_update_lock_timeout` | another run held the lock too long |
| `shards_candidate_rejected` / `shards_candidate_empty` / `shards_candidate_invalid` | candidate rejected and why |
| `shards_shrink_detected` / `shards_shrink_transient` / `shards_shrink_unverified` | shrink seen / rejected as transient / consul unreachable |
| `shards_added` / `shards_removed` / `shards_candidate_hosts` | host set changes |

`shards_candidate_rejected` and `shards_shrink_transient` are the ones worth alerting on: they mean a render would have disconnected jibri from a shard that is still healthy.

## Testing

- `bash -n` and shellcheck clean on the wrapper.
- `consul-passing-hosts.py` tested against a fake consul endpoint: union of both services, `prosody_client_port` honoured, node address used when the service address is empty, exit 1 on connection failure.
- Host-set extraction and diff helpers exercised against an ansible-rendered and a consul-template-rendered `xmpp.conf` (multi-host `["a", "b"]` lines, removed + added hosts, empty file).
- `consul-template.cfg.j2` rendered with the new stanza and produces valid HCL (`wait = "15s:60s"`, `command_timeout = "300s"`).
- Playbook YAML parses; the only ansible-lint hit in the file is a pre-existing long line.

Not yet run against a live jibri. Suggested rollout: one jibri on a stage environment, then watch `/var/log/jitsi/jibri-shards/jibri-reconfigure.log` and the metrics above through a release.

## Follow-ups (not in this PR)

- `jibri-docker-compose` has its own copy of `reconfigure-jibri-wrapper.sh` with the same "exit non-zero kills the runner" behaviour; it should get the same treatment.
- Why the shard stayed out of the passing set long enough to be rendered out is a consul-side question (the `consul-signal` role restarts the consul agent on the shard when its service file changes, which briefly drops the node from the catalog). The debounce and the shrink check here make jibri robust to that, but the flap itself is still worth looking at.

